### PR TITLE
feat: start Phase 2 toolchain (Hardhat 2 plugin, --watch, Foundry recipe)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,22 @@ jobs:
         run: pnpm install
       - name: Build
         run: pnpm -r run --if-present build
+
+  plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.98"
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build fhec binary
+        run: cargo build -p fhec-cli
+      - name: Test Hardhat plugin
+        run: pnpm --filter @fhec/hardhat-plugin test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-`.fsol` → readable CoFHE Solidity. Dual workspace: Cargo `crates/*` (the compiler) + pnpm `packages/*` (npm wrapper + difftest). Normative behavior is `spec/spec.md` (RFC-2119); section numbers are stable — do not renumber.
+`.fsol` → readable CoFHE Solidity. Dual workspace: Cargo `crates/*` (the compiler) + pnpm `packages/*` (npm wrapper + Hardhat 2 plugin + difftest). Normative behavior is `spec/spec.md` (RFC-2119); section numbers are stable — do not renumber.
 
 ## Commands
 
@@ -22,6 +22,7 @@ cargo test -p fhec-lower --test golden
 cargo test -p fhec-check --test check
 pnpm --filter difftest test          # transpiles then hardhat
 pnpm --filter difftest run check:types
+pnpm --filter @fhec/hardhat-plugin test
 ```
 
 `fixtures_runner` is one `#[test]` per area (all cases). Iterate a single construct in `crates/fhec-{check,lower}/tests/*.rs`, not by hoping cargo will isolate one fixture directory.
@@ -56,7 +57,7 @@ Solar is `git = https://github.com/toml01/solar` at a workspace-pinned rev (all 
 - No `euint256`. Profile types: `ebool`, `euint8/16/32/64/128`, `eaddress`.
 - Existing FHE library calls the profile does not understand are left to solc — do not reject them.
 
-Out of scope unless asked: Hardhat/Foundry plugins, decrypt/reveal, other FHE targets, LSP, formatter.
+Out of scope unless asked: Hardhat 3 plugin, decrypt/reveal, other FHE targets, LSP, formatter.
 
 ## Diagnostics
 
@@ -82,7 +83,8 @@ CI rust job does **not** install solc or CoFHE, so a green workspace test is not
 
 ## `packages/`
 
-- `fhec` — esbuild/biome-style binary shim. Resolution: `FHEC_BINARY_PATH` → platform package → `target/{release,debug}/fhec`. `build:native` only stages **darwin-arm64**; other hosts skip the smoke tests.
+- `fhec` — esbuild/biome-style binary shim. Resolution lives in `lib/resolve.js` and is exported as `fhec/resolve`: `FHEC_BINARY_PATH` → platform package → `target/{release,debug}/fhec`. `build:native` only stages **darwin-arm64**; other hosts skip the smoke tests.
+- `hardhat-plugin` (`@fhec/hardhat-plugin`) — Hardhat 2 only. Runs `fhec build` before compile, repoints `paths.sources` at `out`, remaps solc spans via `generated/.fhec/manifest.json`. Do not implement Hardhat 3. Do not deploy CoFHE mocks (that is `@cofhe/hardhat-plugin`). Plugin tests resolve the native binary via `FHEC_BINARY_PATH` or `target/{release,debug}/fhec` — never require `build:native`.
 - `difftest` — Hardhat 2 harness (`node >= 22`). Exact version pins (no `^`/`~`). Do not bump Hardhat to 3 (Dependabot ignores that major). Compare plaintext, ACL `isAllowed`, and revert **identity** — **never ciphertext handles**. Mint encrypted inputs per side via `args: async (ctx) => …` (`encryptInput`). Write `*Ref.sol` independently; never copy fhec output as the oracle. Mock bootstrap lives in `src/mocks.ts` — do not reinvent it.
 
 ## Env (solc)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -516,6 +516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +588,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -779,6 +794,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +935,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,7 +1042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1073,6 +1111,7 @@ name = "fhec-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "ctrlc",
  "fhec-bind",
  "fhec-check",
  "fhec-emit",
@@ -1082,6 +1121,7 @@ dependencies = [
  "fhec-targets",
  "fhec-verify",
  "globset",
+ "notify-debouncer-mini",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -1180,6 +1220,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -1417,6 +1466,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.13.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inturn"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1641,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1700,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1734,45 @@ name = "normalize-path"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "num-bigint"
@@ -1667,6 +1819,21 @@ dependencies = [
  "autocfg",
  "libm",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -2123,7 +2290,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2131,6 +2298,15 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schemars"
@@ -2418,7 +2594,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -2451,7 +2627,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -2568,7 +2744,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2800,6 +2976,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +3043,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2920,12 +3115,86 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ preserved byte-for-byte — comments, formatting, everything.
 | `fhec build` | `check`, then patch, write the `generated/` mirror + manifest, and compile with solc |
 | `fhec explain FHEnnnn` | Explain a diagnostic code (full catalog from the spec) |
 | `fhec clean` | Remove generated output |
+| `fhec config` | Print the effective `fhec.toml` as JSON |
 
 | Flag | Meaning |
 |---|---|
@@ -85,10 +86,52 @@ preserved byte-for-byte — comments, formatting, everything.
 | `--fix` | Apply safe fix-its to the source |
 | `--acl=insert\|suggest` | Insert ACL grants (default) or downgrade them to fix-it notes |
 | `--no-verify` | Skip the solc gate |
+| `--watch` | Rebuild or recheck when dialect sources or `fhec.toml` change (`build` / `check` only) |
 
 Diagnostics carry stable codes (`FHE1xxx` load/parse … `FHE9xxx` internal),
 original-source spans, and fix-its; solc errors on generated code are remapped
 back to `.fsol` positions through the manifest.
+
+## Hardhat 2
+
+`@fhec/hardhat-plugin` runs `fhec build` before `hardhat compile`, points
+`paths.sources` at the generated tree, and remaps solc diagnostics back to
+`.fsol`. CoFHE mocks still come from `@cofhe/hardhat-plugin`. Hardhat 3 is
+out of scope.
+
+```js
+// hardhat.config.js
+require("@fhec/hardhat-plugin");
+
+module.exports = {
+  solidity: { version: "0.8.28", settings: { evmVersion: "cancun" } },
+};
+```
+
+See [`packages/hardhat-plugin/README.md`](packages/hardhat-plugin/README.md)
+for config keys (`enabled`, `verify`, `acl`, `config`) and FHE5003 version
+checking.
+
+## Foundry
+
+There is no Foundry plugin. Transpile first, then let `forge` compile the
+generated tree:
+
+```console
+$ fhec build && forge build
+```
+
+Point Foundry at `generated/` either as `src` or via a remapping:
+
+```toml
+# foundry.toml
+[profile.default]
+src = "generated"
+solc = "0.8.28"
+evm_version = "cancun"
+# alternatively, keep src = "contracts" and remap:
+# remappings = ["contracts/=generated/"]
+```
 
 ## Repository layout
 
@@ -107,23 +150,25 @@ back to `.fsol` positions through the manifest.
 | `spec/` | The normative `.fsol` language specification |
 | `fixtures/` | Conformance corpus: golden, rejection, no-op, and source-map suites |
 | `packages/fhec` | npm wrapper (esbuild/biome-style platform-binary distribution) |
+| `packages/hardhat-plugin` | Hardhat 2 plugin: transpile before compile, remap solc spans |
 | `packages/difftest` | Differential-execution harness on the CoFHE mocks |
 
 ## Status
 
-**Phase 1 (Core + CLI MVP) is complete.** Working today: all operators and
-comparisons over encrypted types, encrypted `if`/ternary via select lowering
-with branch versioning, plaintext/literal coercion and width widening,
-automatic ACL insertion (R1/R2/R3) with dedupe, the `in euintX` parameter
-sugar, stable diagnostics with fix-its, deterministic byte-range emission with
-source maps, the solc compile gate, and a conformance corpus plus a
-differential-execution suite that proves transpiled contracts equivalent to
-hand-written references on the CoFHE mocks (plaintexts, ACL state, and revert
-parity).
+**Phase 2 has started.** Phase 1 (Core + CLI MVP) is complete: all operators
+and comparisons over encrypted types, encrypted `if`/ternary via select
+lowering with branch versioning, plaintext/literal coercion and width
+widening, automatic ACL insertion (R1/R2/R3) with dedupe, the `in euintX`
+parameter sugar, stable diagnostics with fix-its, deterministic byte-range
+emission with source maps, the solc compile gate, and a conformance corpus
+plus a differential-execution suite that proves transpiled contracts
+equivalent to hand-written references on the CoFHE mocks (plaintexts, ACL
+state, and revert parity). The Hardhat 2 plugin (`@fhec/hardhat-plugin`)
+transpiles before compile and remaps solc diagnostics to `.fsol`.
 
-Explicitly not yet in scope (later phases): Hardhat/Foundry plugins,
-decrypt/reveal syntax, ACL annotations, flow-based ACL, the Zama fhevm / Inco
-/ COTI targets, LSP/editor tooling, and a formatter.
+Explicitly not yet in scope (later phases): Hardhat 3, a vocs docs site, a
+template repo, decrypt/reveal syntax, ACL annotations, flow-based ACL, the
+Zama fhevm / Inco / COTI targets, LSP/editor tooling, and a formatter.
 
 ## Related work
 

--- a/crates/fhec-cli/Cargo.toml
+++ b/crates/fhec-cli/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "`fhec` binary: build/check/init/explain/clean"
+description = "`fhec` binary: build/check/init/explain/clean/config"
 
 [lib]
 name = "fhec_cli"
@@ -24,7 +24,9 @@ fhec-lower = { path = "../fhec-lower" }
 fhec-syntax = { path = "../fhec-syntax" }
 fhec-targets = { path = "../fhec-targets" }
 fhec-verify = { path = "../fhec-verify" }
+ctrlc = "3"
 globset = "0.4"
+notify-debouncer-mini = "0.6"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/fhec-cli/src/commands.rs
+++ b/crates/fhec-cli/src/commands.rs
@@ -7,6 +7,7 @@ use crate::load::{discover, LoadedUnit};
 use crate::stages::{self, FileOutput, StageOptions};
 use fhec_emit::{Manifest, ManifestFile};
 use fhec_lower::AclMode;
+use serde::Serialize;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -26,6 +27,8 @@ pub struct GlobalArgs {
     pub no_verify: bool,
     /// Hidden: re-transpile the generated output and assert byte identity.
     pub self_check: bool,
+    /// Rebuild or recheck when dialect sources or `fhec.toml` change.
+    pub watch: bool,
 }
 
 impl GlobalArgs {
@@ -52,7 +55,8 @@ fn report(diags: &[Diagnostic], json: bool, lookup: impl Fn(&str) -> Option<Stri
     }
 }
 
-fn load_project(g: &GlobalArgs) -> Result<LoadedConfig, Box<Diagnostic>> {
+/// Load `fhec.toml` the same way every command does (`--config` or upward search).
+pub(crate) fn load_project(g: &GlobalArgs) -> Result<LoadedConfig, Box<Diagnostic>> {
     let cwd = std::env::current_dir().expect("cwd is accessible");
     load_config(&cwd, g.config.as_deref())
 }
@@ -507,6 +511,52 @@ pub fn cmd_init() -> i32 {
     println!("created contracts/Counter.fsol");
     println!("next: run `fhec check`");
     0
+}
+
+/// Effective configuration printed by `fhec config`. `strictness` and the raw
+/// file text are intentionally omitted; `Config` already skips `strictness`.
+#[derive(Serialize)]
+struct EffectiveConfig<'a> {
+    root: String,
+    path: String,
+    hash: String,
+    #[serde(flatten)]
+    config: &'a crate::config::Config,
+}
+
+fn abs_display(path: &Path) -> String {
+    std::path::absolute(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Print the effective loaded configuration as JSON on stdout.
+pub fn cmd_config(g: &GlobalArgs) -> i32 {
+    let loaded = match load_project(g) {
+        Ok(l) => l,
+        Err(d) => {
+            let text = std::fs::read_to_string(&d.span.file).ok();
+            report(&[*d], g.json, |_| text.clone());
+            return 1;
+        }
+    };
+    let payload = EffectiveConfig {
+        root: abs_display(&loaded.root),
+        path: abs_display(&loaded.path),
+        hash: loaded.config.hash(),
+        config: &loaded.config,
+    };
+    match serde_json::to_string_pretty(&payload) {
+        Ok(json) => {
+            println!("{json}");
+            0
+        }
+        Err(e) => {
+            eprintln!("fhec: cannot serialize config: {e}");
+            2
+        }
+    }
 }
 
 pub fn cmd_explain(code: &str) -> i32 {

--- a/crates/fhec-cli/src/lib.rs
+++ b/crates/fhec-cli/src/lib.rs
@@ -1,4 +1,4 @@
-//! `fhec` binary: build/check/init/explain/clean.
+//! `fhec` binary: build/check/init/explain/clean/config.
 //!
 //! Library layout (the binary in `main.rs` is a thin clap shell):
 //! - [`config`] — stage 1: `fhec.toml` model, upward search, content hash
@@ -8,6 +8,7 @@
 //! - [`diag`] — spec §10.2 diagnostic model, human + JSON renderers
 //! - [`explain`] — static spec §9 catalog for `fhec explain`
 //! - [`commands`] — command drivers returning exit codes
+//! - [`watch`] — `--watch` loop for `build` and `check`
 
 pub mod commands;
 pub mod config;
@@ -16,3 +17,4 @@ pub mod explain;
 pub mod gate;
 pub mod load;
 pub mod stages;
+pub mod watch;

--- a/crates/fhec-cli/src/main.rs
+++ b/crates/fhec-cli/src/main.rs
@@ -42,6 +42,10 @@ struct Cli {
     #[arg(long, global = true, hide = true)]
     self_check: bool,
 
+    /// Rebuild or recheck when dialect sources or fhec.toml change.
+    #[arg(long, global = true)]
+    watch: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -61,6 +65,8 @@ enum Command {
     },
     /// Remove the generated out dir.
     Clean,
+    /// Print the effective fhec.toml as JSON.
+    Config,
 }
 
 fn main() {
@@ -83,13 +89,21 @@ fn main() {
         acl,
         no_verify: cli.no_verify,
         self_check: cli.self_check,
+        watch: cli.watch,
     };
     let code = match cli.command {
+        Command::Build if g.watch => fhec_cli::watch::cmd_watch(&g, commands::cmd_build),
+        Command::Check if g.watch => fhec_cli::watch::cmd_watch(&g, commands::cmd_check),
         Command::Build => commands::cmd_build(&g),
         Command::Check => commands::cmd_check(&g),
+        Command::Init | Command::Explain { .. } | Command::Clean | Command::Config if g.watch => {
+            eprintln!("fhec: --watch is only valid with build or check");
+            2
+        }
         Command::Init => commands::cmd_init(),
         Command::Explain { code } => commands::cmd_explain(&code),
         Command::Clean => commands::cmd_clean(&g),
+        Command::Config => commands::cmd_config(&g),
     };
     std::process::exit(code);
 }

--- a/crates/fhec-cli/src/watch.rs
+++ b/crates/fhec-cli/src/watch.rs
@@ -1,0 +1,240 @@
+//! `--watch` loop for `build` and `check`.
+//!
+//! The one-shot commands stay one-shot. This module runs them immediately,
+//! then rebuilds when `fhec.toml` or a dialect source under `src` changes.
+
+use crate::commands::{load_project, GlobalArgs};
+use crate::config::LoadedConfig;
+use notify_debouncer_mini::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Debounce window for coalescing editor save storms.
+const DEBOUNCE: Duration = Duration::from_millis(250);
+
+/// Run `run` once, then again whenever a watched dialect source or `fhec.toml`
+/// changes. Returns the last command exit code on Ctrl-C or watcher shutdown.
+pub fn cmd_watch(g: &GlobalArgs, run: fn(&GlobalArgs) -> i32) -> i32 {
+    let loaded = match load_project(g) {
+        Ok(l) => l,
+        Err(_) => return run(g),
+    };
+    if let Err(code) = refuse_unsafe_watch(&loaded) {
+        return code;
+    }
+
+    let last = run(g);
+    watch_loop(g, &loaded, run, last)
+}
+
+fn refuse_unsafe_watch(loaded: &LoadedConfig) -> Result<(), i32> {
+    let Ok(root) = loaded.root.canonicalize() else {
+        eprintln!("fhec: --watch cannot resolve project root");
+        return Err(2);
+    };
+    let src = resolve_for_compare(&loaded.config.src_dir(&loaded.root));
+    let out = resolve_for_compare(&loaded.config.out_dir(&loaded.root));
+    if out == src {
+        eprintln!(
+            "fhec: --watch refusing — out dir equals src dir ({})",
+            out.display()
+        );
+        return Err(2);
+    }
+    if !out.starts_with(&root) || out == root {
+        eprintln!(
+            "fhec: --watch refusing — out dir {} is not inside the project root {}",
+            out.display(),
+            root.display()
+        );
+        return Err(2);
+    }
+    Ok(())
+}
+
+fn resolve_for_compare(path: &Path) -> PathBuf {
+    path.canonicalize()
+        .unwrap_or_else(|_| std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf()))
+}
+
+fn watch_loop(
+    g: &GlobalArgs,
+    loaded: &LoadedConfig,
+    run: fn(&GlobalArgs) -> i32,
+    mut last: i32,
+) -> i32 {
+    let src = resolve_for_compare(&loaded.config.src_dir(&loaded.root));
+    let out = resolve_for_compare(&loaded.config.out_dir(&loaded.root));
+    let config_path = resolve_for_compare(&loaded.path);
+
+    let (tx, rx) = mpsc::channel();
+    let mut debouncer = match new_debouncer(DEBOUNCE, move |res: DebounceEventResult| {
+        let _ = tx.send(res);
+    }) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("fhec: --watch cannot start file watcher: {e}");
+            return 2;
+        }
+    };
+
+    // Never watch `out`. Recursive `src` may still deliver events from a nested
+    // out dir; `should_rebuild` drops those.
+    if src.exists() {
+        if let Err(e) = debouncer.watcher().watch(&src, RecursiveMode::Recursive) {
+            eprintln!("fhec: --watch cannot watch {}: {e}", src.display());
+            return 2;
+        }
+    }
+    if let Err(e) = debouncer
+        .watcher()
+        .watch(&config_path, RecursiveMode::NonRecursive)
+    {
+        eprintln!("fhec: --watch cannot watch {}: {e}", config_path.display());
+        return 2;
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    {
+        let stop = Arc::clone(&stop);
+        if let Err(e) = ctrlc::set_handler(move || {
+            stop.store(true, Ordering::SeqCst);
+        }) {
+            // Still watch; a later SIGINT will use the default terminate.
+            eprintln!("fhec: --watch cannot install Ctrl-C handler: {e}");
+        }
+    }
+
+    loop {
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(Ok(events)) => {
+                let rebuild = events
+                    .iter()
+                    .any(|event| should_rebuild(&event.path, &src, &out, &config_path));
+                if rebuild {
+                    eprintln!("fhec: rebuilding (source changed)");
+                    last = run(g);
+                }
+            }
+            Ok(Err(_)) => {
+                // Transient watcher errors: keep the loop alive.
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if stop.load(Ordering::SeqCst) {
+                    return last;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => return last,
+        }
+    }
+}
+
+/// Whether a filesystem event should trigger another `build`/`check`.
+///
+/// Ignores the out directory, editor junk, and anything that is not `fhec.toml`
+/// or a `.fsol`/`.sol` file.
+pub(crate) fn should_rebuild(path: &Path, src: &Path, out: &Path, config_path: &Path) -> bool {
+    if is_under(path, out) {
+        return false;
+    }
+    if is_editor_junk(path) {
+        return false;
+    }
+    if path == config_path || file_name_eq(path, "fhec.toml") {
+        return true;
+    }
+    if !is_under(path, src) {
+        return false;
+    }
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("fsol") | Some("sol")
+    )
+}
+
+fn is_under(path: &Path, dir: &Path) -> bool {
+    path == dir || path.starts_with(dir)
+}
+
+fn is_editor_junk(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    name.starts_with('.') || name.ends_with('~') || name.ends_with(".swp") || name.ends_with(".swo")
+}
+
+fn file_name_eq(path: &Path, expected: &str) -> bool {
+    path.file_name().and_then(|n| n.to_str()) == Some(expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn p(s: &str) -> &Path {
+        Path::new(s)
+    }
+
+    fn check(path: &str) -> bool {
+        should_rebuild(
+            p(path),
+            p("/proj/contracts"),
+            p("/proj/generated"),
+            p("/proj/fhec.toml"),
+        )
+    }
+
+    #[test]
+    fn rebuilds_on_dialect_sources() {
+        assert!(check("/proj/contracts/A.fsol"));
+        assert!(check("/proj/contracts/nested/B.sol"));
+    }
+
+    #[test]
+    fn rebuilds_on_config() {
+        assert!(check("/proj/fhec.toml"));
+    }
+
+    #[test]
+    fn ignores_out_dir_even_for_sol() {
+        assert!(!check("/proj/generated/A.sol"));
+        assert!(!check("/proj/generated/nested/B.fsol"));
+        assert!(!check("/proj/generated"));
+    }
+
+    #[test]
+    fn ignores_out_nested_inside_src() {
+        assert!(!should_rebuild(
+            p("/proj/contracts/generated/A.sol"),
+            p("/proj/contracts"),
+            p("/proj/contracts/generated"),
+            p("/proj/fhec.toml"),
+        ));
+        assert!(should_rebuild(
+            p("/proj/contracts/A.fsol"),
+            p("/proj/contracts"),
+            p("/proj/contracts/generated"),
+            p("/proj/fhec.toml"),
+        ));
+    }
+
+    #[test]
+    fn ignores_editor_junk() {
+        assert!(!check("/proj/contracts/A.fsol~"));
+        assert!(!check("/proj/contracts/.A.fsol"));
+        assert!(!check("/proj/contracts/A.fsol.swp"));
+        assert!(!check("/proj/contracts/A.fsol.swo"));
+        assert!(!check("/proj/.fhec.toml"));
+    }
+
+    #[test]
+    fn ignores_unrelated_paths() {
+        assert!(!check("/proj/contracts/README.md"));
+        assert!(!check("/proj/contracts/subdir"));
+        assert!(!check("/proj/README.md"));
+    }
+}

--- a/crates/fhec-cli/tests/cli.rs
+++ b/crates/fhec-cli/tests/cli.rs
@@ -114,6 +114,66 @@ fn invalid_acl_mode_is_rejected() {
 }
 
 #[test]
+fn init_then_config_prints_effective_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(fhec(tmp.path(), &["init"]).status.code(), Some(0));
+
+    let out = fhec(tmp.path(), &["config"]);
+    assert_eq!(out.status.code(), Some(0), "config: {}", stderr(&out));
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout(&out)).expect("config stdout is JSON");
+    let obj = parsed.as_object().expect("object");
+    assert_eq!(obj["project"]["src"], "contracts");
+    assert_eq!(obj["project"]["out"], "generated");
+    assert_eq!(obj["target"]["profile"], "cofhe");
+    assert_eq!(obj["acl"]["mode"], "insert");
+    let path = obj["path"].as_str().expect("path string");
+    assert!(path.ends_with("fhec.toml"), "path: {path}");
+    let root = obj["root"].as_str().expect("root string");
+    assert_eq!(
+        Path::new(root).canonicalize().unwrap(),
+        tmp.path().canonicalize().unwrap()
+    );
+    let hash = obj["hash"].as_str().expect("hash string");
+    assert_eq!(hash.len(), 64, "hash: {hash}");
+    assert!(hash.chars().all(|c| c.is_ascii_hexdigit()), "hash: {hash}");
+    assert!(!obj.contains_key("strictness"));
+    assert!(!obj.contains_key("text"));
+}
+
+#[test]
+fn config_missing_reports_draft_code() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = fhec(tmp.path(), &["config"]);
+    // Guard: if some ancestor of the tempdir carries a fhec.toml this test
+    // cannot assert anything meaningful.
+    if out.status.code() == Some(0) {
+        return;
+    }
+    assert_eq!(out.status.code(), Some(1));
+    assert!(stderr(&out).contains("FHE1004"), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn watch_rejected_on_non_build_commands() {
+    let tmp = tempfile::tempdir().unwrap();
+    for args in [
+        ["init", "--watch"].as_slice(),
+        ["explain", "FHE2007", "--watch"].as_slice(),
+        ["clean", "--watch"].as_slice(),
+        ["config", "--watch"].as_slice(),
+    ] {
+        let out = fhec(tmp.path(), args);
+        assert_eq!(out.status.code(), Some(2), "args: {args:?}");
+        assert!(
+            stderr(&out).contains("--watch is only valid with build or check"),
+            "stderr: {}",
+            stderr(&out)
+        );
+    }
+}
+
+#[test]
 fn clean_removes_only_the_out_dir() {
     let tmp = tempfile::tempdir().unwrap();
     assert_eq!(fhec(tmp.path(), &["init"]).status.code(), Some(0));

--- a/packages/fhec/README.md
+++ b/packages/fhec/README.md
@@ -4,11 +4,12 @@ npm wrapper for the `fhec` native binary (the Rust CLI in `crates/fhec-cli`),
 following the platform-package distribution model used by esbuild and
 biome: this package is a thin JS entry point (`bin/fhec.js`) that finds a
 prebuilt native binary for the current platform/arch and execs it,
-forwarding args and exit code.
+forwarding args and exit code. Resolution lives in `lib/resolve.js` and
+is exported as `fhec/resolve` for the Hardhat plugin and other tooling.
 
 ## Binary resolution order
 
-`bin/fhec.js` looks for the native binary in this order, stopping at the
+`fhec/resolve` looks for the native binary in this order, stopping at the
 first one it finds:
 
 1. **`FHEC_BINARY_PATH`** — if set, used as-is (existence-checked).

--- a/packages/fhec/bin/fhec.js
+++ b/packages/fhec/bin/fhec.js
@@ -1,96 +1,14 @@
 #!/usr/bin/env node
 // `fhec` npm wrapper entry point.
 //
-// Resolves the native `fhec` binary in this order:
-//   1. FHEC_BINARY_PATH env var, if set (used as-is, existence-checked).
-//   2. The optional platform package for the current platform+arch, e.g.
-//      `@fhec/cli-darwin-arm64`, resolved via require.resolve and expected
-//      to ship the binary at <pkg>/bin/fhec.
-//   3. A dev fallback: ../../target/release/fhec then
-//      ../../target/debug/fhec, resolved relative to this script (i.e. a
-//      cargo build done directly in this monorepo checkout).
-//
-// This mirrors the platform-package distribution model used by esbuild and
-// biome: a thin JS shim spawns a prebuilt native binary chosen for the
-// current platform/arch.
+// Resolves the native binary via `fhec/resolve` (`../lib/resolve.js`) and
+// execs it, forwarding args and the exit code. See that module for the
+// resolution order (FHEC_BINARY_PATH → platform package → cargo target/).
 
 "use strict";
 
-const path = require("node:path");
-const fs = require("node:fs");
 const { spawnSync } = require("node:child_process");
-
-const BINARY_NAME = process.platform === "win32" ? "fhec.exe" : "fhec";
-
-// process.platform/process.arch -> platform package suffix, following the
-// same naming convention as esbuild/biome's per-platform packages.
-const PLATFORM_PACKAGES = {
-  "darwin-arm64": "@fhec/cli-darwin-arm64",
-  "darwin-x64": "@fhec/cli-darwin-x64",
-  "linux-x64": "@fhec/cli-linux-x64",
-  "linux-arm64": "@fhec/cli-linux-arm64",
-  "win32-x64": "@fhec/cli-win32-x64",
-  "win32-arm64": "@fhec/cli-win32-arm64",
-};
-
-/**
- * Attempts every resolution strategy in order, recording what was tried.
- * Returns { binaryPath } on success, or throws with a message listing every
- * location that was tried.
- */
-function resolveBinary() {
-  const tried = [];
-
-  // (a) explicit override.
-  const override = process.env.FHEC_BINARY_PATH;
-  if (override) {
-    tried.push(`FHEC_BINARY_PATH=${override}`);
-    if (fs.existsSync(override)) {
-      return { binaryPath: override };
-    }
-  }
-
-  // (b) platform package for the current platform+arch.
-  const platformKey = `${process.platform}-${process.arch}`;
-  const pkgName = PLATFORM_PACKAGES[platformKey];
-  if (pkgName) {
-    let pkgJsonPath;
-    try {
-      pkgJsonPath = require.resolve(`${pkgName}/package.json`);
-    } catch {
-      tried.push(`platform package ${pkgName} (not installed)`);
-    }
-    if (pkgJsonPath) {
-      const candidate = path.join(path.dirname(pkgJsonPath), "bin", BINARY_NAME);
-      tried.push(candidate);
-      if (fs.existsSync(candidate)) {
-        return { binaryPath: candidate };
-      }
-    }
-  } else {
-    tried.push(`platform package (no mapping for ${platformKey})`);
-  }
-
-  // (c) dev fallback: a local cargo build in this checkout.
-  for (const profile of ["release", "debug"]) {
-    const candidate = path.resolve(__dirname, "..", "..", "..", "target", profile, BINARY_NAME);
-    tried.push(candidate);
-    if (fs.existsSync(candidate)) {
-      return { binaryPath: candidate };
-    }
-  }
-
-  const lines = [
-    "fhec: could not find the native binary. Tried, in order:",
-    ...tried.map((t) => `  - ${t}`),
-    "",
-    "To fix this:",
-    "  - set FHEC_BINARY_PATH to an existing fhec binary, or",
-    "  - install the platform package for your platform/arch, or",
-    "  - run `pnpm --filter fhec run build:native` in this checkout to build one locally.",
-  ];
-  throw new Error(lines.join("\n"));
-}
+const { resolveBinary } = require("../lib/resolve");
 
 function main() {
   let binaryPath;

--- a/packages/fhec/lib/resolve.d.ts
+++ b/packages/fhec/lib/resolve.d.ts
@@ -1,0 +1,18 @@
+/** Platform package name keyed by `${process.platform}-${process.arch}`. */
+export const PLATFORM_PACKAGES: Record<string, string>;
+
+/** `fhec.exe` on win32, otherwise `fhec`. */
+export const BINARY_NAME: string;
+
+/**
+ * Builds the "could not find the native binary" error text, including every
+ * location that was tried and the same fix hints the CLI wrapper prints.
+ */
+export function formatResolveFailure(tried: string[]): string;
+
+/**
+ * Attempts every resolution strategy in order.
+ * Returns `{ binaryPath }` on success, or throws with a message listing every
+ * location that was tried.
+ */
+export function resolveBinary(): { binaryPath: string };

--- a/packages/fhec/lib/resolve.js
+++ b/packages/fhec/lib/resolve.js
@@ -1,0 +1,109 @@
+// Resolves the native `fhec` binary in this order:
+//   1. FHEC_BINARY_PATH env var, if set (used as-is, existence-checked).
+//   2. The optional platform package for the current platform+arch, e.g.
+//      `@fhec/cli-darwin-arm64`, resolved via require.resolve and expected
+//      to ship the binary at <pkg>/bin/fhec.
+//   3. A dev fallback: ../../../target/release/fhec then
+//      ../../../target/debug/fhec, resolved relative to this file (i.e. a
+//      cargo build done directly in this monorepo checkout).
+//
+// This mirrors the platform-package distribution model used by esbuild and
+// biome: a thin JS shim spawns a prebuilt native binary chosen for the
+// current platform/arch.
+//
+// Require as `fhec/resolve` (or `../lib/resolve` from bin/fhec.js).
+
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+const BINARY_NAME = process.platform === "win32" ? "fhec.exe" : "fhec";
+
+// process.platform/process.arch -> platform package suffix, following the
+// same naming convention as esbuild/biome's per-platform packages.
+const PLATFORM_PACKAGES = {
+  "darwin-arm64": "@fhec/cli-darwin-arm64",
+  "darwin-x64": "@fhec/cli-darwin-x64",
+  "linux-x64": "@fhec/cli-linux-x64",
+  "linux-arm64": "@fhec/cli-linux-arm64",
+  "win32-x64": "@fhec/cli-win32-x64",
+  "win32-arm64": "@fhec/cli-win32-arm64",
+};
+
+/**
+ * Builds the "could not find the native binary" error text, including every
+ * location that was tried and the same fix hints the CLI wrapper prints.
+ * @param {string[]} tried
+ * @returns {string}
+ */
+function formatResolveFailure(tried) {
+  return [
+    "fhec: could not find the native binary. Tried, in order:",
+    ...tried.map((t) => `  - ${t}`),
+    "",
+    "To fix this:",
+    "  - set FHEC_BINARY_PATH to an existing fhec binary, or",
+    "  - install the platform package for your platform/arch, or",
+    "  - run `pnpm --filter fhec run build:native` in this checkout to build one locally.",
+  ].join("\n");
+}
+
+/**
+ * Attempts every resolution strategy in order, recording what was tried.
+ * Returns `{ binaryPath }` on success, or throws with a message listing every
+ * location that was tried.
+ * @returns {{ binaryPath: string }}
+ */
+function resolveBinary() {
+  const tried = [];
+
+  // (a) explicit override.
+  const override = process.env.FHEC_BINARY_PATH;
+  if (override) {
+    tried.push(`FHEC_BINARY_PATH=${override}`);
+    if (fs.existsSync(override)) {
+      return { binaryPath: override };
+    }
+  }
+
+  // (b) platform package for the current platform+arch.
+  const platformKey = `${process.platform}-${process.arch}`;
+  const pkgName = PLATFORM_PACKAGES[platformKey];
+  if (pkgName) {
+    let pkgJsonPath;
+    try {
+      pkgJsonPath = require.resolve(`${pkgName}/package.json`);
+    } catch {
+      tried.push(`platform package ${pkgName} (not installed)`);
+    }
+    if (pkgJsonPath) {
+      const candidate = path.join(path.dirname(pkgJsonPath), "bin", BINARY_NAME);
+      tried.push(candidate);
+      if (fs.existsSync(candidate)) {
+        return { binaryPath: candidate };
+      }
+    }
+  } else {
+    tried.push(`platform package (no mapping for ${platformKey})`);
+  }
+
+  // (c) dev fallback: a local cargo build in this checkout.
+  // this file lives at packages/fhec/lib/resolve.js → repo root is ../../..
+  for (const profile of ["release", "debug"]) {
+    const candidate = path.resolve(__dirname, "..", "..", "..", "target", profile, BINARY_NAME);
+    tried.push(candidate);
+    if (fs.existsSync(candidate)) {
+      return { binaryPath: candidate };
+    }
+  }
+
+  throw new Error(formatResolveFailure(tried));
+}
+
+module.exports = {
+  resolveBinary,
+  formatResolveFailure,
+  PLATFORM_PACKAGES,
+  BINARY_NAME,
+};

--- a/packages/fhec/package.json
+++ b/packages/fhec/package.json
@@ -5,6 +5,12 @@
   "bin": {
     "fhec": "bin/fhec.js"
   },
+  "exports": {
+    "./resolve": {
+      "types": "./lib/resolve.d.ts",
+      "default": "./lib/resolve.js"
+    }
+  },
   "scripts": {
     "build:native": "node scripts/build-native.mjs",
     "test": "node --test test/**/*.test.mjs"

--- a/packages/fhec/test/smoke.test.mjs
+++ b/packages/fhec/test/smoke.test.mjs
@@ -18,7 +18,7 @@ const pkgRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(pkgRoot, "..", "..");
 const cliJs = path.join(pkgRoot, "bin", "fhec.js");
 
-// Kept in sync with the mapping in bin/fhec.js / scripts/build-native.mjs.
+// Kept in sync with the mapping in lib/resolve.js / scripts/build-native.mjs.
 const PLATFORM_DIRS = {
   "darwin-arm64": "fhec-darwin-arm64",
 };

--- a/packages/hardhat-plugin/README.md
+++ b/packages/hardhat-plugin/README.md
@@ -1,0 +1,95 @@
+# @fhec/hardhat-plugin
+
+Hardhat 2 plugin for [`fhec`](https://github.com/toml01/fhec). It transpiles
+`.fsol` before `hardhat compile`, points Hardhat `paths.sources` at the fhec
+output directory (`generated/` by default), and remaps solc diagnostics from
+generated `.sol` spans back to the original `.fsol` through
+`generated/.fhec/manifest.json`.
+
+Hardhat 3 is out of scope. CoFHE mock deployment is still provided by
+[`@cofhe/hardhat-plugin`](https://www.npmjs.com/package/@cofhe/hardhat-plugin);
+this package does not bootstrap mocks.
+
+## Install
+
+```sh
+npm install --save-dev @fhec/hardhat-plugin
+# or
+pnpm add -D @fhec/hardhat-plugin
+```
+
+The plugin resolves the native `fhec` binary the same way the `fhec` npm
+wrapper does (`fhec/resolve`): `FHEC_BINARY_PATH`, then a platform package,
+then a local `target/{release,debug}/fhec` in a monorepo checkout.
+
+Also install `@fhenixprotocol/cofhe-contracts` for any contract that imports
+it. If that package is installed but its version does not satisfy the
+`[target].version` pin in `fhec.toml` (for example `0.2.x` → `>=0.2.0 <0.3.0`),
+the plugin hard-fails with **FHE5003**. If it is not installed, the check is
+skipped and solc will fail on the import as usual.
+
+## Usage
+
+```js
+// hardhat.config.js
+require("@fhec/hardhat-plugin");
+// Optional: CoFHE mocks for tests / `hardhat node`.
+// require("@cofhe/hardhat-plugin");
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: {
+    version: "0.8.28",
+    settings: { evmVersion: "cancun" },
+  },
+  fhec: {
+    // enabled: true,
+    // verify: false,
+    // acl: "insert",
+    // config: "./fhec.toml",
+  },
+};
+```
+
+TypeScript:
+
+```ts
+import { HardhatUserConfig } from "hardhat/config";
+import "@fhec/hardhat-plugin";
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: "0.8.28",
+    settings: { evmVersion: "cancun" },
+  },
+};
+
+export default config;
+```
+
+Run `fhec init` (or write a `fhec.toml`) in the Hardhat project root. On
+load, if the plugin is enabled and a config file is found, `paths.sources`
+is set to `<root>/<out>` so Hardhat compiles the generated tree. On
+`hardhat compile` the plugin runs `fhec build --no-verify` first.
+
+If no `fhec.toml` is present at compile time, the plugin throws and tells
+you to run `fhec init` (or set `fhec.enabled: false`).
+
+## Config keys
+
+| Key | Default | Meaning |
+|---|---|---|
+| `fhec.enabled` | `true` | Run `fhec build` before compile and repoint `paths.sources`. |
+| `fhec.verify` | `false` | When `false`, pass `--no-verify` (Hardhat is the solc). When `true`, fhec also runs its solc gate. |
+| `fhec.acl` | (unset) | Pass `--acl=insert` or `--acl=suggest`. Unset leaves `fhec.toml` in charge. |
+| `fhec.config` | (search) | Path to `fhec.toml`. Relative paths are resolved from the Hardhat project root. |
+
+`[project].src` / `[project].out` / `[target].version` are read from
+`fhec.toml`. Defaults match the CLI: `contracts`, `generated`, `0.2.x`.
+
+## Compatibility
+
+- Hardhat **2** only (`peerDependencies.hardhat: ^2.0.0`). Do not use with Hardhat 3.
+- Compatible with `@cofhe/hardhat-plugin`: that plugin appends mock sources
+  via `GET_SOURCE_PATHS` and deploys mocks on `test` / `node`. This plugin
+  does not touch those tasks.

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@fhec/hardhat-plugin",
+  "version": "0.1.0",
+  "description": "Hardhat 2 plugin: transpile .fsol with fhec before compile and remap solc diagnostics to original sources",
+  "license": "MIT",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "tsc && node --test test/*.test.js",
+    "check:types": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "hardhat": "^2.0.0"
+  },
+  "dependencies": {
+    "fhec": "workspace:*",
+    "smol-toml": "1.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.10.5",
+    "hardhat": "2.29.1",
+    "typescript": "5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/toml01/fhec.git",
+    "directory": "packages/hardhat-plugin"
+  }
+}

--- a/packages/hardhat-plugin/src/build.ts
+++ b/packages/hardhat-plugin/src/build.ts
@@ -1,0 +1,102 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+
+import type { HardhatRuntimeEnvironment } from "hardhat/types";
+import { HardhatPluginError } from "hardhat/plugins";
+
+import { resolveTomlPath } from "./toml";
+import { PLUGIN_NAME } from "./types";
+import { readInstalledCofheVersion, versionSatisfies } from "./version";
+
+const nodeRequire = createRequire(__filename);
+
+interface ResolveModule {
+  resolveBinary: () => { binaryPath: string };
+}
+
+/**
+ * Runs `fhec build` in the Hardhat project, optionally checking the installed
+ * `@fhenixprotocol/cofhe-contracts` version (FHE5003).
+ */
+export function runFhecBuild(hre: HardhatRuntimeEnvironment): void {
+  const fhec = hre.config.fhec;
+  if (!fhec.enabled) {
+    return;
+  }
+
+  const projectRoot = hre.config.paths.root;
+  const tomlPath = resolveExistingToml(projectRoot, fhec.config, fhec.tomlPath);
+
+  let binaryPath: string;
+  try {
+    ({ binaryPath } = (nodeRequire("fhec/resolve") as ResolveModule).resolveBinary());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new HardhatPluginError(PLUGIN_NAME, message);
+  }
+
+  assertCofheVersion(projectRoot, fhec.profileVersion);
+
+  const args = ["build"];
+  if (!fhec.verify) {
+    args.push("--no-verify");
+  }
+  if (fhec.acl !== undefined) {
+    args.push(`--acl=${fhec.acl}`);
+  }
+  args.push("--config", tomlPath);
+
+  const result = spawnSync(binaryPath, args, {
+    cwd: projectRoot,
+    stdio: "inherit",
+  });
+
+  if (result.error !== undefined) {
+    throw new HardhatPluginError(
+      PLUGIN_NAME,
+      `failed to run ${binaryPath}: ${result.error.message}`,
+    );
+  }
+  if (result.signal !== null && result.signal !== undefined) {
+    throw new HardhatPluginError(
+      PLUGIN_NAME,
+      `fhec build terminated by signal ${result.signal}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new HardhatPluginError(PLUGIN_NAME, "fhec build failed");
+  }
+}
+
+function resolveExistingToml(
+  projectRoot: string,
+  explicit: string | undefined,
+  cached: string | undefined,
+): string {
+  if (cached !== undefined && existsSync(cached)) {
+    return cached;
+  }
+  const found = resolveTomlPath(projectRoot, explicit);
+  if (found === undefined || !existsSync(found)) {
+    throw new HardhatPluginError(
+      PLUGIN_NAME,
+      "No fhec.toml found. Run `fhec init` to create one, or set `fhec.enabled: false` in your Hardhat config.",
+    );
+  }
+  return found;
+}
+
+function assertCofheVersion(projectRoot: string, profileVersion: string): void {
+  const installed = readInstalledCofheVersion(projectRoot);
+  if (installed === undefined) {
+    return;
+  }
+  if (versionSatisfies(profileVersion, installed)) {
+    return;
+  }
+  throw new HardhatPluginError(
+    PLUGIN_NAME,
+    `Installed @fhenixprotocol/cofhe-contracts@${installed} does not satisfy the pinned profile version ${profileVersion} (FHE5003).`,
+  );
+}

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -1,0 +1,99 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import {
+  TASK_COMPILE,
+  TASK_COMPILE_SOLIDITY_RUN_SOLC,
+  TASK_COMPILE_SOLIDITY_RUN_SOLCJS,
+} from "hardhat/builtin-tasks/task-names";
+import { extendConfig, subtask, task } from "hardhat/config";
+import { HardhatPluginError } from "hardhat/plugins";
+import type { HardhatConfig, HardhatUserConfig } from "hardhat/types";
+
+import { runFhecBuild } from "./build";
+import { loadManifest, remapSolcOutput, type RemapContext } from "./remap";
+import { loadFhecToml, resolveTomlPath } from "./toml";
+import {
+  DEFAULT_OUT,
+  DEFAULT_PROFILE_VERSION,
+  DEFAULT_SRC,
+  PLUGIN_NAME,
+  type FhecConfig,
+} from "./types";
+
+import "./type-extensions";
+
+export type { FhecConfig, FhecUserConfig, ParsedFhecToml } from "./types";
+export { parseFhecToml, findConfig, resolveTomlPath } from "./toml";
+export { remapRange, matchManifestFile, displaySourcePath, remapSolcOutput } from "./remap";
+export { versionSatisfies, parseSemver } from "./version";
+
+extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
+  const user = userConfig.fhec ?? {};
+  const resolved: FhecConfig = {
+    enabled: user.enabled ?? true,
+    verify: user.verify ?? false,
+    acl: user.acl,
+    config: user.config,
+    srcDir: DEFAULT_SRC,
+    outDir: DEFAULT_OUT,
+    profileVersion: DEFAULT_PROFILE_VERSION,
+  };
+
+  if (resolved.enabled) {
+    const tomlPath = resolveTomlPath(config.paths.root, resolved.config);
+    if (tomlPath !== undefined && existsSync(tomlPath)) {
+      let parsed;
+      try {
+        parsed = loadFhecToml(tomlPath);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new HardhatPluginError(
+          PLUGIN_NAME,
+          `invalid fhec.toml at ${tomlPath}: ${message}`,
+        );
+      }
+      resolved.tomlPath = tomlPath;
+      resolved.srcDir = parsed.src;
+      resolved.outDir = parsed.out;
+      resolved.profileVersion = parsed.version;
+      config.paths.sources = path.resolve(config.paths.root, parsed.out);
+    }
+  }
+
+  config.fhec = resolved;
+});
+
+task(TASK_COMPILE, async (args, hre, runSuper) => {
+  runFhecBuild(hre);
+  return runSuper(args);
+});
+
+function remapAfterSolc(output: unknown, hre: { config: HardhatConfig }): unknown {
+  const fhec = hre.config.fhec;
+  if (!fhec.enabled) {
+    return output;
+  }
+  const manifest = loadManifest(hre.config.paths.sources);
+  if (manifest === undefined) {
+    return output;
+  }
+  const ctx: RemapContext = {
+    manifest,
+    outDir: fhec.outDir,
+    srcDir: fhec.srcDir,
+    projectRoot: hre.config.paths.root,
+    sourcesDir: hre.config.paths.sources,
+  };
+  return remapSolcOutput(output as { errors?: never[] }, ctx);
+}
+
+subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC, async (args, hre, runSuper) => {
+  const output: unknown = await runSuper(args);
+  return remapAfterSolc(output, hre);
+});
+
+subtask(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, async (args, hre, runSuper) => {
+  const output: unknown = await runSuper(args);
+  return remapAfterSolc(output, hre);
+});

--- a/packages/hardhat-plugin/src/remap.ts
+++ b/packages/hardhat-plugin/src/remap.ts
@@ -1,0 +1,245 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import type { Manifest, ManifestFile } from "./types";
+
+/**
+ * Maps `[start, end)` in output coordinates onto source coordinates using a
+ * manifest file's mappings (sorted by output range).
+ *
+ * Port of `crates/fhec-cli/src/gate.rs` `remap_range`:
+ * - A position inside a mapping's output range blames the whole source range
+ *   of that mapping and sets `insideGenerated = true`.
+ * - Otherwise shift by the last mapping whose `output_range[1] <= start`
+ *   using `delta = output_end - source_end`.
+ */
+export function remapRange(
+  file: ManifestFile,
+  start: number,
+  end: number,
+): { start: number; end: number; insideGenerated: boolean } {
+  for (const mapping of file.mappings) {
+    const outStart = mapping.output_range[0];
+    const outEnd = mapping.output_range[1];
+    if (start >= outStart && start < Math.max(outEnd, outStart + 1)) {
+      return {
+        start: mapping.source_range[0],
+        end: mapping.source_range[1],
+        insideGenerated: true,
+      };
+    }
+  }
+
+  let delta = 0;
+  for (const mapping of file.mappings) {
+    if (mapping.output_range[1] <= start) {
+      delta = mapping.output_range[1] - mapping.source_range[1];
+    } else {
+      break;
+    }
+  }
+  const shift = (value: number): number => Math.max(0, value - delta);
+  return { start: shift(start), end: shift(end), insideGenerated: false };
+}
+
+/**
+ * Loads `generated/.fhec/manifest.json` from the (already-repointed) Hardhat
+ * sources directory. Returns `undefined` when the file is missing or invalid.
+ */
+export function loadManifest(sourcesDir: string): Manifest | undefined {
+  const manifestPath = path.join(sourcesDir, ".fhec", "manifest.json");
+  if (!existsSync(manifestPath)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as Manifest;
+    if (!Array.isArray(parsed.files)) {
+      return undefined;
+    }
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Matches a Hardhat/solc source name (`generated/Counter.sol`) to a manifest
+ * `output` (`Counter.sol`) by stripping the out-dir prefix.
+ */
+export function matchManifestFile(
+  solcFile: string,
+  outDir: string,
+  manifest: Manifest,
+): ManifestFile | undefined {
+  const normalized = solcFile.replace(/\\/g, "/");
+  const prefix = outDir.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/\/+$/, "");
+  let rel = normalized;
+  if (prefix.length > 0 && (normalized === prefix || normalized.startsWith(`${prefix}/`))) {
+    rel = normalized === prefix ? "" : normalized.slice(prefix.length + 1);
+  }
+  return manifest.files.find((file) => file.output.replace(/\\/g, "/") === rel);
+}
+
+/**
+ * Project-relative path shown to the user, e.g. `contracts/Counter.fsol`.
+ */
+export function displaySourcePath(srcDir: string, source: string): string {
+  const src = srcDir.replace(/\\/g, "/").replace(/\/+$/, "");
+  const rel = source.replace(/\\/g, "/");
+  if (src.length === 0 || src === ".") {
+    return rel;
+  }
+  return `${src}/${rel}`;
+}
+
+interface SolcLocation {
+  file: string;
+  start: number;
+  end: number;
+  message?: string;
+}
+
+interface SolcError {
+  sourceLocation?: SolcLocation;
+  secondarySourceLocations?: SolcLocation[];
+  formattedMessage?: string;
+}
+
+interface SolcOutput {
+  errors?: SolcError[];
+}
+
+export interface RemapContext {
+  manifest: Manifest;
+  outDir: string;
+  srcDir: string;
+  projectRoot: string;
+  sourcesDir: string;
+}
+
+/**
+ * Rewrites `output.errors[]` so paths and byte ranges point at the original
+ * `.fsol` (or pass-through `.sol`) instead of `generated/*.sol`.
+ *
+ * Errors that do not match a manifest file, or that have no usable range,
+ * are left unchanged.
+ */
+export function remapSolcOutput<T extends SolcOutput>(output: T, ctx: RemapContext): T {
+  if (output.errors === undefined || output.errors.length === 0) {
+    return output;
+  }
+  for (const error of output.errors) {
+    remapError(error, ctx);
+  }
+  return output;
+}
+
+function remapError(error: SolcError, ctx: RemapContext): void {
+  if (error.sourceLocation !== undefined) {
+    const remapped = remapLocation(error.sourceLocation, ctx);
+    if (remapped !== undefined) {
+      if (error.formattedMessage !== undefined) {
+        error.formattedMessage = rewriteFormattedMessage(
+          error.formattedMessage,
+          error.sourceLocation,
+          remapped,
+          ctx,
+        );
+      }
+      error.sourceLocation = remapped;
+    }
+  }
+  if (error.secondarySourceLocations !== undefined) {
+    error.secondarySourceLocations = error.secondarySourceLocations.map((loc) => {
+      return remapLocation(loc, ctx) ?? loc;
+    });
+  }
+}
+
+function remapLocation(loc: SolcLocation, ctx: RemapContext): SolcLocation | undefined {
+  const file = matchManifestFile(loc.file, ctx.outDir, ctx.manifest);
+  if (file === undefined) {
+    return undefined;
+  }
+  const display = displaySourcePath(ctx.srcDir, file.source);
+  if (loc.start < 0) {
+    return { ...loc, file: display };
+  }
+  const remapped = remapRange(file, loc.start, loc.end);
+  return { ...loc, file: display, start: remapped.start, end: remapped.end };
+}
+
+/**
+ * Rewrites solc's pretty-printed `formattedMessage` so the path (and, when
+ * we can compute them, the line/column) name the original source.
+ */
+export function rewriteFormattedMessage(
+  formatted: string,
+  original: SolcLocation,
+  remapped: SolcLocation,
+  ctx: RemapContext,
+): string {
+  let next = replaceAll(formatted, original.file, remapped.file);
+  if (original.start < 0 || remapped.start < 0) {
+    return next;
+  }
+  const generatedText = readUtf8(path.join(ctx.sourcesDir, manifestRelFromSolc(original.file, ctx.outDir)));
+  const sourceText = readUtf8(path.join(ctx.projectRoot, remapped.file));
+  if (generatedText === undefined || sourceText === undefined) {
+    return next;
+  }
+  const oldLoc = byteOffsetToLineCol(generatedText, original.start);
+  const newLoc = byteOffsetToLineCol(sourceText, remapped.start);
+  if (oldLoc.line !== newLoc.line || oldLoc.column !== newLoc.column) {
+    next = replaceAll(
+      next,
+      `${remapped.file}:${oldLoc.line}:${oldLoc.column}`,
+      `${remapped.file}:${newLoc.line}:${newLoc.column}`,
+    );
+  }
+  return next;
+}
+
+function manifestRelFromSolc(solcFile: string, outDir: string): string {
+  const normalized = solcFile.replace(/\\/g, "/");
+  const prefix = outDir.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/\/+$/, "");
+  if (prefix.length > 0 && normalized.startsWith(`${prefix}/`)) {
+    return normalized.slice(prefix.length + 1);
+  }
+  return normalized;
+}
+
+function readUtf8(filePath: string): string | undefined {
+  try {
+    return readFileSync(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Converts a UTF-8 byte offset to a 1-based line/column (columns count
+ * UTF-8 bytes), matching spec §10.2 / AGENTS.md.
+ */
+export function byteOffsetToLineCol(source: string, offset: number): { line: number; column: number } {
+  const bytes = Buffer.from(source, "utf8");
+  const end = Math.max(0, Math.min(offset, bytes.length));
+  let line = 1;
+  let column = 1;
+  for (let i = 0; i < end; i++) {
+    if (bytes[i] === 0x0a) {
+      line += 1;
+      column = 1;
+    } else {
+      column += 1;
+    }
+  }
+  return { line, column };
+}
+
+function replaceAll(haystack: string, needle: string, replacement: string): string {
+  if (needle.length === 0) {
+    return haystack;
+  }
+  return haystack.split(needle).join(replacement);
+}

--- a/packages/hardhat-plugin/src/toml.ts
+++ b/packages/hardhat-plugin/src/toml.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { parse } from "smol-toml";
+
+import {
+  CONFIG_FILE_NAME,
+  DEFAULT_OUT,
+  DEFAULT_PROFILE_VERSION,
+  DEFAULT_SRC,
+  type ParsedFhecToml,
+} from "./types";
+
+/**
+ * Searches for `fhec.toml` upward from `start`, returning the first hit.
+ * Mirrors `fhec-cli` `find_config`.
+ */
+export function findConfig(start: string): string | undefined {
+  let dir = path.resolve(start);
+  for (;;) {
+    const candidate = path.join(dir, CONFIG_FILE_NAME);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Resolves the config path: an explicit `fhec.config` value, otherwise an
+ * upward search from the Hardhat project root.
+ */
+export function resolveTomlPath(projectRoot: string, explicit?: string): string | undefined {
+  if (explicit !== undefined && explicit !== "") {
+    return path.isAbsolute(explicit) ? explicit : path.resolve(projectRoot, explicit);
+  }
+  return findConfig(projectRoot);
+}
+
+/**
+ * Parses only the `fhec.toml` keys this plugin needs. Missing tables fall
+ * back to the same defaults as `fhec-cli` (`src`, `out`, `target.version`).
+ */
+export function parseFhecToml(text: string): ParsedFhecToml {
+  const data = parse(text) as {
+    project?: { src?: unknown; out?: unknown };
+    target?: { version?: unknown };
+  };
+  return {
+    src: stringOrDefault(data.project?.src, DEFAULT_SRC),
+    out: stringOrDefault(data.project?.out, DEFAULT_OUT),
+    version: stringOrDefault(data.target?.version, DEFAULT_PROFILE_VERSION),
+  };
+}
+
+/**
+ * Reads and parses `fhec.toml` from disk.
+ */
+export function loadFhecToml(tomlPath: string): ParsedFhecToml {
+  const text = readFileSync(tomlPath, "utf8");
+  return parseFhecToml(text);
+}
+
+function stringOrDefault(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}

--- a/packages/hardhat-plugin/src/type-extensions.ts
+++ b/packages/hardhat-plugin/src/type-extensions.ts
@@ -1,0 +1,13 @@
+import "hardhat/types/config";
+
+import type { FhecConfig, FhecUserConfig } from "./types";
+
+declare module "hardhat/types/config" {
+  interface HardhatUserConfig {
+    fhec?: FhecUserConfig;
+  }
+
+  interface HardhatConfig {
+    fhec: FhecConfig;
+  }
+}

--- a/packages/hardhat-plugin/src/types.ts
+++ b/packages/hardhat-plugin/src/types.ts
@@ -1,0 +1,79 @@
+/**
+ * User-facing Hardhat config for `@fhec/hardhat-plugin`.
+ */
+export interface FhecUserConfig {
+  /** Run `fhec build` before compile. Default `true`. */
+  enabled?: boolean;
+  /**
+   * When `false` (default), pass `--no-verify` so Hardhat is the only solc.
+   * When `true`, let fhec run its own solc gate as well.
+   */
+  verify?: boolean;
+  /** Override the ACL mode from `fhec.toml`. */
+  acl?: "insert" | "suggest";
+  /** Path to `fhec.toml` (relative to the Hardhat project root, or absolute). */
+  config?: string;
+}
+
+/**
+ * Resolved plugin config stored on `HardhatConfig.fhec`.
+ */
+export interface FhecConfig {
+  enabled: boolean;
+  verify: boolean;
+  acl?: "insert" | "suggest";
+  config?: string;
+  /** Absolute path of the `fhec.toml` discovered at config-load time, if any. */
+  tomlPath?: string;
+  /** `[project].src`, default `contracts`. */
+  srcDir: string;
+  /** `[project].out`, default `generated`. */
+  outDir: string;
+  /** `[target].version`, default `0.2.x`. */
+  profileVersion: string;
+}
+
+/**
+ * The keys of `fhec.toml` this plugin reads. Unknown tables are ignored.
+ */
+export interface ParsedFhecToml {
+  src: string;
+  out: string;
+  version: string;
+}
+
+/**
+ * One output-range → source-range mapping from `generated/.fhec/manifest.json`.
+ */
+export interface ManifestMapping {
+  output_range: [number, number];
+  source_range: [number, number];
+  rule: string;
+  code?: string;
+}
+
+/**
+ * Source-map data for one emitted file.
+ */
+export interface ManifestFile {
+  output: string;
+  source: string;
+  no_op: boolean;
+  mappings: ManifestMapping[];
+}
+
+/**
+ * The whole-run sidecar manifest (`generated/.fhec/manifest.json`).
+ */
+export interface Manifest {
+  tool: string;
+  version: string;
+  files: ManifestFile[];
+}
+
+export const PLUGIN_NAME = "@fhec/hardhat-plugin";
+
+export const DEFAULT_SRC = "contracts";
+export const DEFAULT_OUT = "generated";
+export const DEFAULT_PROFILE_VERSION = "0.2.x";
+export const CONFIG_FILE_NAME = "fhec.toml";

--- a/packages/hardhat-plugin/src/version.ts
+++ b/packages/hardhat-plugin/src/version.ts
@@ -1,0 +1,75 @@
+/**
+ * Profile version matching for FHE5003.
+ *
+ * A profile pin of the form `X.Y.x` means `>=X.Y.0 <X.(Y+1).0`.
+ * Anything else is compared as an exact string (or as a prefix followed by `.`).
+ */
+
+export interface ParsedSemver {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/**
+ * Parses a leading `X.Y.Z` from an npm version string. Returns `undefined`
+ * when the string is not a recognizable semver.
+ */
+export function parseSemver(version: string): ParsedSemver | undefined {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version.trim());
+  if (match === null) {
+    return undefined;
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+/**
+ * Whether `installed` satisfies the pinned profile version.
+ *
+ * `0.2.x` accepts `0.2.0` and rejects `0.1.5`.
+ */
+export function versionSatisfies(profileVersion: string, installed: string): boolean {
+  const pin = profileVersion.trim();
+  const wildcard = /^(\d+)\.(\d+)\.x$/.exec(pin);
+  if (wildcard !== null) {
+    const parsed = parseSemver(installed);
+    if (parsed === undefined) {
+      return false;
+    }
+    return parsed.major === Number(wildcard[1]) && parsed.minor === Number(wildcard[2]);
+  }
+  const installedTrimmed = installed.trim();
+  return installedTrimmed === pin || installedTrimmed.startsWith(`${pin}.`);
+}
+
+/**
+ * Reads `@fhenixprotocol/cofhe-contracts/package.json` from `projectRoot`.
+ * Returns `undefined` when the package is not installed (solc will fail on
+ * the import; we do not hard-fail here).
+ */
+export function readInstalledCofheVersion(
+  projectRoot: string,
+  resolver: (request: string, paths: string[]) => string = defaultResolve,
+  readJson: (filePath: string) => { version?: unknown } = defaultReadJson,
+): string | undefined {
+  let pkgJsonPath: string;
+  try {
+    pkgJsonPath = resolver("@fhenixprotocol/cofhe-contracts/package.json", [projectRoot]);
+  } catch {
+    return undefined;
+  }
+  const version = readJson(pkgJsonPath).version;
+  return typeof version === "string" && version.length > 0 ? version : undefined;
+}
+
+function defaultResolve(request: string, paths: string[]): string {
+  return require.resolve(request, { paths });
+}
+
+function defaultReadJson(filePath: string): { version?: unknown } {
+  return require(filePath) as { version?: unknown };
+}

--- a/packages/hardhat-plugin/test/compile.test.js
+++ b/packages/hardhat-plugin/test/compile.test.js
@@ -1,0 +1,146 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const pluginRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(pluginRoot, "..", "..");
+const pluginEntry = path.join(pluginRoot, "dist", "index.js");
+const binaryName = process.platform === "win32" ? "fhec.exe" : "fhec";
+
+// NOTE: must stay `undefined` (not `null`) when nothing needs skipping —
+// node:test's `skip` option treats any defined value, including `null`, as
+// "skip this test". Same trap as packages/fhec/test/smoke.test.mjs.
+let skipReason;
+
+function findNativeBinary() {
+  const override = process.env.FHEC_BINARY_PATH;
+  if (override && fs.existsSync(override)) {
+    return override;
+  }
+  for (const profile of ["release", "debug"]) {
+    const candidate = path.join(repoRoot, "target", profile, binaryName);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+const nativeBinary = findNativeBinary();
+if (nativeBinary === undefined) {
+  skipReason =
+    "no native fhec binary (set FHEC_BINARY_PATH or cargo build -p fhec-cli)";
+}
+
+function hardhatCli() {
+  return require.resolve("hardhat/internal/cli/cli.js", { paths: [pluginRoot] });
+}
+
+function linkLocalHardhat(dir) {
+  const hardhatDir = path.dirname(
+    require.resolve("hardhat/package.json", { paths: [pluginRoot] }),
+  );
+  const nm = path.join(dir, "node_modules");
+  fs.mkdirSync(nm, { recursive: true });
+  fs.symlinkSync(hardhatDir, path.join(nm, "hardhat"));
+}
+
+function writeProject(dir, { sourceName, sourceBody }) {
+  fs.mkdirSync(path.join(dir, "contracts"), { recursive: true });
+  linkLocalHardhat(dir);
+  fs.writeFileSync(
+    path.join(dir, "hardhat.config.js"),
+    `'use strict';
+require(${JSON.stringify(pluginEntry)});
+module.exports = {
+  solidity: {
+    version: "0.8.28",
+    settings: { evmVersion: "cancun" },
+  },
+};
+`,
+  );
+  fs.writeFileSync(
+    path.join(dir, "fhec.toml"),
+    `[project]
+src = "contracts"
+out = "generated"
+`,
+  );
+  fs.writeFileSync(path.join(dir, "contracts", sourceName), sourceBody);
+}
+
+function runCompile(dir, binary) {
+  return spawnSync(process.execPath, [hardhatCli(), "compile"], {
+    cwd: dir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      FHEC_BINARY_PATH: binary,
+      HARDHAT_DISABLE_TELEMETRY: "true",
+    },
+    timeout: 180_000,
+  });
+}
+
+function artifactExists(dir, contractFile, contractName) {
+  const candidates = [
+    path.join(dir, "artifacts", "generated", contractFile, `${contractName}.json`),
+    path.join(dir, "artifacts", contractFile, `${contractName}.json`),
+  ];
+  return candidates.some((p) => fs.existsSync(p));
+}
+
+test(
+  "hardhat compile transpiles a no-FHE .fsol and writes artifacts",
+  { skip: skipReason, timeout: 180_000 },
+  () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-hh-ok-"));
+    try {
+      writeProject(dir, {
+        sourceName: "C.fsol",
+        sourceBody: "pragma solidity ^0.8.25; contract C { uint public x; }\n",
+      });
+      const result = runCompile(dir, nativeBinary);
+      assert.equal(
+        result.status,
+        0,
+        `compile failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      );
+      assert.ok(fs.existsSync(path.join(dir, "generated", "C.sol")), "expected generated/C.sol");
+      assert.ok(artifactExists(dir, "C.sol", "C"), "expected Hardhat artifact for C");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "solc errors mention Broken.fsol, not only generated/Broken.sol",
+  { skip: skipReason, timeout: 180_000 },
+  () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-hh-broken-"));
+    try {
+      writeProject(dir, {
+        sourceName: "Broken.fsol",
+        sourceBody:
+          "pragma solidity ^0.8.25;\ncontract Broken {\n    function f() public {\n        notDefined();\n    }\n}\n",
+      });
+      const result = runCompile(dir, nativeBinary);
+      assert.notEqual(result.status, 0, "expected Hardhat compile to fail");
+      const combined = `${result.stdout}\n${result.stderr}`;
+      assert.match(
+        combined,
+        /Broken\.fsol/,
+        `expected remapped .fsol path in compiler output\n${combined}`,
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/hardhat-plugin/test/config.test.js
+++ b/packages/hardhat-plugin/test/config.test.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { parseFhecToml, findConfig } = require("../dist/toml");
+const { versionSatisfies, parseSemver } = require("../dist/version");
+
+test("empty toml uses defaults", () => {
+  assert.deepEqual(parseFhecToml(""), {
+    src: "contracts",
+    out: "generated",
+    version: "0.2.x",
+  });
+});
+
+test("parses [project].out and leaves other defaults", () => {
+  const parsed = parseFhecToml(`[project]\nout = "build/out"\n`);
+  assert.equal(parsed.out, "build/out");
+  assert.equal(parsed.src, "contracts");
+  assert.equal(parsed.version, "0.2.x");
+});
+
+test("parses src, out, and target.version together", () => {
+  const parsed = parseFhecToml(`
+[project]
+src = "src"
+out = "out"
+
+[target]
+profile = "cofhe"
+version = "0.2.x"
+`);
+  assert.deepEqual(parsed, { src: "src", out: "out", version: "0.2.x" });
+});
+
+test("0.2.x satisfies 0.2.0 and rejects 0.1.5", () => {
+  assert.equal(versionSatisfies("0.2.x", "0.2.0"), true);
+  assert.equal(versionSatisfies("0.2.x", "0.2.9"), true);
+  assert.equal(versionSatisfies("0.2.x", "0.1.5"), false);
+  assert.equal(versionSatisfies("0.2.x", "0.3.0"), false);
+});
+
+test("parseSemver reads a leading X.Y.Z", () => {
+  assert.deepEqual(parseSemver("0.2.0"), { major: 0, minor: 2, patch: 0 });
+  assert.deepEqual(parseSemver("v1.4.8-rc.1"), { major: 1, minor: 4, patch: 8 });
+  assert.equal(parseSemver("not-a-version"), undefined);
+});
+
+test("findConfig walks upward and returns the nearest fhec.toml", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-hh-cfg-"));
+  try {
+    const nested = path.join(root, "a", "b");
+    fs.mkdirSync(nested, { recursive: true });
+    const toml = path.join(root, "fhec.toml");
+    fs.writeFileSync(toml, "");
+    assert.equal(findConfig(nested), toml);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/hardhat-plugin/test/remap.test.js
+++ b/packages/hardhat-plugin/test/remap.test.js
@@ -1,0 +1,155 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  remapRange,
+  matchManifestFile,
+  displaySourcePath,
+  remapSolcOutput,
+  byteOffsetToLineCol,
+} = require("../dist/remap");
+
+// Sample from crates/fhec-emit/src/manifest.rs tests.
+function sampleManifest() {
+  return {
+    tool: "fhec",
+    version: "0.0.0",
+    files: [
+      {
+        output: "A.sol",
+        source: "A.fsol",
+        no_op: false,
+        mappings: [
+          {
+            output_range: [120, 155],
+            source_range: [120, 131],
+            rule: "operator-lowering",
+          },
+          {
+            output_range: [200, 245],
+            source_range: [180, 180],
+            rule: "§8.1 R1",
+            code: "FHE4001",
+          },
+        ],
+      },
+      {
+        output: "B.sol",
+        source: "B.sol",
+        no_op: true,
+        mappings: [],
+      },
+    ],
+  };
+}
+
+test("start inside first mapping blames the whole source range", () => {
+  const file = sampleManifest().files[0];
+  assert.deepEqual(remapRange(file, 120, 130), {
+    start: 120,
+    end: 131,
+    insideGenerated: true,
+  });
+});
+
+test("start after mappings shifts by the last mapping delta", () => {
+  const file = sampleManifest().files[0];
+  // last mapping with output_end <= 250 is [200, 245] → delta = 245 - 180 = 65
+  assert.deepEqual(remapRange(file, 250, 260), {
+    start: 185,
+    end: 195,
+    insideGenerated: false,
+  });
+});
+
+test("start between mappings uses the previous mapping's delta", () => {
+  const file = sampleManifest().files[0];
+  // last mapping with output_end <= 180 is [120, 155] → delta = 155 - 131 = 24
+  assert.deepEqual(remapRange(file, 180, 190), {
+    start: 156,
+    end: 166,
+    insideGenerated: false,
+  });
+});
+
+test("no-op file with empty mappings leaves offsets unchanged", () => {
+  const file = sampleManifest().files[1];
+  assert.deepEqual(remapRange(file, 40, 55), {
+    start: 40,
+    end: 55,
+    insideGenerated: false,
+  });
+});
+
+test("position before the first mapping is identity", () => {
+  const file = sampleManifest().files[0];
+  assert.deepEqual(remapRange(file, 10, 20), {
+    start: 10,
+    end: 20,
+    insideGenerated: false,
+  });
+});
+
+test("matchManifestFile strips the out-dir prefix", () => {
+  const manifest = sampleManifest();
+  const hit = matchManifestFile("generated/A.sol", "generated", manifest);
+  assert.equal(hit && hit.source, "A.fsol");
+  assert.equal(matchManifestFile("contracts/A.sol", "generated", manifest), undefined);
+});
+
+test("displaySourcePath joins src dir and manifest source", () => {
+  assert.equal(displaySourcePath("contracts", "Counter.fsol"), "contracts/Counter.fsol");
+  assert.equal(displaySourcePath("contracts", "nested/C.fsol"), "contracts/nested/C.fsol");
+});
+
+test("remapSolcOutput rewrites file, range, and formattedMessage path", () => {
+  const manifest = sampleManifest();
+  const output = {
+    errors: [
+      {
+        sourceLocation: { file: "generated/A.sol", start: 120, end: 140 },
+        formattedMessage: "TypeError: nope\n --> generated/A.sol:6:1:\n",
+      },
+    ],
+  };
+  remapSolcOutput(output, {
+    manifest,
+    outDir: "generated",
+    srcDir: "contracts",
+    projectRoot: path.join(__dirname, "does-not-exist"),
+    sourcesDir: path.join(__dirname, "does-not-exist"),
+  });
+  assert.equal(output.errors[0].sourceLocation.file, "contracts/A.fsol");
+  assert.equal(output.errors[0].sourceLocation.start, 120);
+  assert.equal(output.errors[0].sourceLocation.end, 131);
+  assert.match(output.errors[0].formattedMessage, /contracts\/A\.fsol/);
+  assert.doesNotMatch(output.errors[0].formattedMessage, /generated\/A\.sol/);
+});
+
+test("remapSolcOutput leaves unmatched files unchanged", () => {
+  const output = {
+    errors: [
+      {
+        sourceLocation: { file: "node_modules/lib/X.sol", start: 4, end: 8 },
+        formattedMessage: " --> node_modules/lib/X.sol:1:5:\n",
+      },
+    ],
+  };
+  remapSolcOutput(output, {
+    manifest: sampleManifest(),
+    outDir: "generated",
+    srcDir: "contracts",
+    projectRoot: "/tmp",
+    sourcesDir: "/tmp/generated",
+  });
+  assert.equal(output.errors[0].sourceLocation.file, "node_modules/lib/X.sol");
+  assert.equal(output.errors[0].sourceLocation.start, 4);
+});
+
+test("byteOffsetToLineCol is 1-based and counts UTF-8 bytes", () => {
+  assert.deepEqual(byteOffsetToLineCol("ab\ncd", 0), { line: 1, column: 1 });
+  assert.deepEqual(byteOffsetToLineCol("ab\ncd", 3), { line: 2, column: 1 });
+});

--- a/packages/hardhat-plugin/tsconfig.json
+++ b/packages/hardhat-plugin/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,25 @@ importers:
 
   packages/fhec-darwin-arm64: {}
 
+  packages/hardhat-plugin:
+    dependencies:
+      fhec:
+        specifier: workspace:*
+        version: link:../fhec
+      smol-toml:
+        specifier: 1.8.0
+        version: 1.8.0
+    devDependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
+      hardhat:
+        specifier: 2.29.1
+        version: 2.29.1(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.9.3))(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
 packages:
 
   '@adraffy/ens-normalize@1.11.1':
@@ -1276,6 +1295,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+    engines: {node: '>= 18'}
 
   solc@0.8.26:
     resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
@@ -2918,6 +2941,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  smol-toml@1.8.0: {}
 
   solc@0.8.26(debug@4.4.3):
     dependencies:


### PR DESCRIPTION
## Summary

Phase 2 first increment: toolchain and developer experience.

- `fhec config` prints the effective `fhec.toml` as JSON.
- `fhec build --watch` and `fhec check --watch` rebuild when `.fsol`, `.sol`, or `fhec.toml` change. The watcher does not watch `generated/`.
- `@fhec/hardhat-plugin` runs `fhec build` before Hardhat compile, points `paths.sources` at `generated/`, and remaps solc diagnostics to `.fsol` through the emit manifest.
- `fhec/resolve` is the shared native-binary resolver.
- CI has a `plugin` job that builds `fhec-cli` and runs the plugin tests.
- The README includes a Foundry recipe (`fhec build && forge build`).

Hardhat 3, a Foundry plugin, vocs docs, and a template repo stay out of scope.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p fhec-cli`
- `pnpm --filter @fhec/hardhat-plugin test` (18 tests)

## Follow-up (not blocking)

- `--watch` keeps the first `src`/`out` roots if `fhec.toml` changes those paths mid-session.
- Plugin FHE5003 is a Hardhat error, not a spec §10.2 diagnostic.
- Atomic editor saves can drop the file watch on `fhec.toml`.