### PR TITLE
feat: dogfood the precondition FHERC20 (Phase 4)

### DIFF
--- a/packages/difftest/contracts-dialect-fherc20/FHERC20.fsol
+++ b/packages/difftest/contracts-dialect-fherc20/FHERC20.fsol
@@ -31,7 +31,9 @@ import {
  * - shared inputs use `in shared euint64`, and directed shared outputs use
  *   `shared(msg.sender) euint64`;
  * - a `precondition` block runs before input proof verification, so the
- *   operator check keeps its upstream position in the From overloads;
+ *   operator check keeps its upstream position in the proof-taking From
+ *   functions; the shared-input From overloads stay receive-first, matching
+ *   upstream, since they never verify a proof;
  * - the {FHESafeMath} library disappears: its checked arithmetic is written
  *   inline in `_update` with encrypted operators (`+`, `-`, `>=`) and
  *   encrypted ternaries (`cond ? a : b`), which lower to `FHE.add`/`FHE.sub`/

--- a/packages/difftest/contracts-dialect-fherc20/FHERC20.fsol
+++ b/packages/difftest/contracts-dialect-fherc20/FHERC20.fsol
@@ -25,17 +25,17 @@ import {
  * the ERC-7201 namespaced struct (the upgradeable, namespaced-storage variant
  * stays with the plain-Solidity reference).
  *
- * What the dialect removes relative to the reference:
- * - `externalEuint64` + `bytes inputProof` parameter pairs and their
- *   `FHE.asEuint64(hash, proof)` verification calls become `in euint64`
- *   parameters (`confidentialTransfer`, `confidentialTransferFrom`);
+ * Dialect syntax used below:
+ * - ordinary external inputs use `in euint64`; positioned-proof inputs use
+ *   `in(inputProof) euint64`;
+ * - shared inputs use `in shared euint64`, and directed shared outputs use
+ *   `shared(msg.sender) euint64`;
+ * - a `precondition` block runs before input proof verification, so the
+ *   operator check keeps its upstream position in the From overloads;
  * - the {FHESafeMath} library disappears: its checked arithmetic is written
  *   inline in `_update` with encrypted operators (`+`, `-`, `>=`) and
  *   encrypted ternaries (`cond ? a : b`), which lower to `FHE.add`/`FHE.sub`/
  *   `FHE.gte`/`FHE.select`;
- * - the AndCall variants keep the explicit external+proof form on purpose:
- *   ERC-7984 fixes their parameter order as (…, encryptedAmount, inputProof,
- *   data), while the sugar always appends the proof last.
  *
  * ACL policy stays fully explicit (this project builds with `acl.mode =
  * "suggest"`): FHERC20 grants balance handles to the affected account, not to
@@ -174,84 +174,74 @@ contract FHERC20 is IFHERC20, ERC165, ReentrancyGuardTransient {
 
     /// @dev `in euint64` sugar: the lowered signature is exactly ERC-7984's
     /// (address to, externalEuint64 encryptedAmount, bytes inputProof).
-    function confidentialTransfer(address to, in euint64 encryptedAmount) public nonReentrant returns (sharedEuint64) {
-        euint64 transferred = _transfer(msg.sender, to, encryptedAmount);
-        return FHE.shareEuint64(transferred, msg.sender);
+    function confidentialTransfer(address to, in euint64 encryptedAmount) public nonReentrant returns (shared(msg.sender) euint64) {
+        return _transfer(msg.sender, to, encryptedAmount);
     }
 
-    function confidentialTransfer(address to, sharedEuint64 sharedAmount) public nonReentrant returns (sharedEuint64) {
-        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
-        euint64 transferred = _transfer(msg.sender, to, amount);
-        return FHE.shareEuint64(transferred, msg.sender);
+    function confidentialTransfer(address to, in shared euint64 amount) external nonReentrant returns (shared(msg.sender) euint64) {
+        return _transfer(msg.sender, to, amount);
     }
 
-    /// @dev `in euint64` sugar; lowered signature matches ERC-7984.
+    /// @dev A precondition preserves operator-check-before-proof-verification.
     function confidentialTransferFrom(
         address from,
         address to,
         in euint64 encryptedAmount
-    ) public nonReentrant returns (sharedEuint64) {
-        if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        euint64 transferred = _transfer(from, to, encryptedAmount);
-        return FHE.shareEuint64(transferred, msg.sender);
+    ) public nonReentrant returns (shared(msg.sender) euint64) {
+        precondition {
+            if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+        }
+        return _transfer(from, to, encryptedAmount);
     }
 
     function confidentialTransferFrom(
         address from,
         address to,
-        sharedEuint64 sharedAmount
-    ) public nonReentrant returns (sharedEuint64) {
-        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
+        in shared euint64 amount
+    ) external nonReentrant returns (shared(msg.sender) euint64) {
         if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        euint64 transferred = _transfer(from, to, amount);
-        return FHE.shareEuint64(transferred, msg.sender);
+        return _transfer(from, to, amount);
     }
 
-    /// @dev No sugar here: ERC-7984 fixes the order (…, inputProof, data),
-    /// while the `in` sugar always appends the proof as the LAST parameter.
     function confidentialTransferAndCall(
         address to,
-        externalEuint64 encryptedAmount,
+        in(inputProof) euint64 encryptedAmount,
         bytes calldata inputProof,
         bytes calldata data
-    ) public nonReentrant returns (sharedEuint64) {
-        euint64 transferred = _transferAndCall(msg.sender, to, FHE.asEuint64(encryptedAmount, inputProof), data);
-        return FHE.shareEuint64(transferred, msg.sender);
+    ) public nonReentrant returns (shared(msg.sender) euint64) {
+        return _transferAndCall(msg.sender, to, encryptedAmount, data);
     }
 
     function confidentialTransferAndCall(
         address to,
-        sharedEuint64 sharedAmount,
+        in shared euint64 amount,
         bytes calldata data
-    ) public nonReentrant returns (sharedEuint64) {
-        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
-        euint64 transferred = _transferAndCall(msg.sender, to, amount, data);
-        return FHE.shareEuint64(transferred, msg.sender);
+    ) external nonReentrant returns (shared(msg.sender) euint64) {
+        return _transferAndCall(msg.sender, to, amount, data);
     }
 
-    /// @dev No sugar: see {confidentialTransferAndCall}.
+    /// @dev A precondition preserves operator-check-before-proof-verification.
     function confidentialTransferFromAndCall(
         address from,
         address to,
-        externalEuint64 encryptedAmount,
+        in(inputProof) euint64 encryptedAmount,
         bytes calldata inputProof,
         bytes calldata data
-    ) public nonReentrant returns (sharedEuint64) {
-        if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        euint64 transferred = _transferAndCall(from, to, FHE.asEuint64(encryptedAmount, inputProof), data);
-        return FHE.shareEuint64(transferred, msg.sender);
+    ) public nonReentrant returns (shared(msg.sender) euint64) {
+        precondition {
+            if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+        }
+        return _transferAndCall(from, to, encryptedAmount, data);
     }
 
     function confidentialTransferFromAndCall(
         address from,
         address to,
-        sharedEuint64 sharedAmount,
+        in shared euint64 amount,
         bytes calldata data
-    ) public nonReentrant returns (sharedEuint64) {
-        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
+    ) external nonReentrant returns (shared(msg.sender) euint64) {
         if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        euint64 transferred = _transferAndCall(from, to, amount, data);
-        return FHE.shareEuint64(transferred, msg.sender);
+        return _transferAndCall(from, to, amount, data);
     }
 
     // =========================================================================

--- a/packages/difftest/contracts/generated-fherc20/.fhec/manifest.json
+++ b/packages/difftest/contracts/generated-fherc20/.fhec/manifest.json
@@ -9,188 +9,606 @@
       "mappings": [
         {
           "output_range": [
-            7530,
-            7567
+            7439,
+            7476
           ],
           "source_range": [
-            7530,
-            7556
+            7439,
+            7465
           ],
           "rule": "§2.3 in-sugar-param"
         },
         {
           "output_range": [
-            7567,
-            7592
+            7476,
+            7501
           ],
           "source_range": [
-            7556,
-            7556
+            7465,
+            7465
           ],
           "rule": "§2.3 in-sugar-proof-param"
         },
         {
           "output_range": [
-            7639,
-            7723
+            7532,
+            7545
           ],
           "source_range": [
-            7603,
-            7603
+            7496,
+            7522
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            7548,
+            7632
+          ],
+          "source_range": [
+            7525,
+            7525
           ],
           "rule": "§2.3 in-sugar-conversion"
         },
         {
           "output_range": [
-            8335,
-            8372
+            7648,
+            7665
           ],
           "source_range": [
+            7541,
+            7541
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            7707,
+            7720
+          ],
+          "source_range": [
+            7583,
+            7583
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            7775,
+            7802
+          ],
+          "source_range": [
+            7638,
+            7662
+          ],
+          "rule": "§2.8 shared-input-param"
+        },
+        {
+          "output_range": [
+            7835,
+            7848
+          ],
+          "source_range": [
+            7695,
+            7721
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            7851,
+            7916
+          ],
+          "source_range": [
+            7724,
+            7724
+          ],
+          "rule": "§2.8 shared-input-receive"
+        },
+        {
+          "output_range": [
+            7932,
+            7949
+          ],
+          "source_range": [
+            7740,
+            7740
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            7982,
+            7995
+          ],
+          "source_range": [
+            7773,
+            7773
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            8173,
+            8210
+          ],
+          "source_range": [
+            7951,
+            7977
+          ],
+          "rule": "§2.3 in-sugar-param"
+        },
+        {
+          "output_range": [
             8215,
-            8241
-          ],
-          "rule": "§2.3 in-sugar-param"
-        },
-        {
-          "output_range": [
-            8377,
-            8402
+            8240
           ],
           "source_range": [
-            8246,
-            8246
+            7982,
+            7982
           ],
           "rule": "§2.3 in-sugar-proof-param"
         },
         {
           "output_range": [
-            8449,
-            8533
+            8271,
+            8284
           ],
           "source_range": [
-            8293,
-            8293
+            8013,
+            8039
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            8296,
+            8296
+          ],
+          "source_range": [
+            8051,
+            8064
+          ],
+          "rule": "§2.7 precondition-marker"
+        },
+        {
+          "output_range": [
+            8407,
+            8491
+          ],
+          "source_range": [
+            8175,
+            8175
           ],
           "rule": "§2.3 in-sugar-conversion"
         },
         {
           "output_range": [
-            13801,
-            13863
+            8507,
+            8524
           ],
           "source_range": [
-            13561,
-            13598
+            8191,
+            8191
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            8560,
+            8573
+          ],
+          "source_range": [
+            8227,
+            8227
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            8671,
+            8698
+          ],
+          "source_range": [
+            8325,
+            8349
+          ],
+          "rule": "§2.8 shared-input-param"
+        },
+        {
+          "output_range": [
+            8736,
+            8749
+          ],
+          "source_range": [
+            8387,
+            8413
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            8752,
+            8817
+          ],
+          "source_range": [
+            8416,
+            8416
+          ],
+          "rule": "§2.8 shared-input-receive"
+        },
+        {
+          "output_range": [
+            8929,
+            8946
+          ],
+          "source_range": [
+            8528,
+            8528
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            8973,
+            8986
+          ],
+          "source_range": [
+            8555,
+            8555
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            9065,
+            9102
+          ],
+          "source_range": [
+            8634,
+            8672
+          ],
+          "rule": "§2.3 in-sugar-param"
+        },
+        {
+          "output_range": [
+            9202,
+            9215
+          ],
+          "source_range": [
+            8772,
+            8798
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            9218,
+            9302
+          ],
+          "source_range": [
+            8801,
+            8801
+          ],
+          "rule": "§2.3 in-sugar-conversion"
+        },
+        {
+          "output_range": [
+            9318,
+            9335
+          ],
+          "source_range": [
+            8817,
+            8817
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            9390,
+            9403
+          ],
+          "source_range": [
+            8872,
+            8872
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            9482,
+            9509
+          ],
+          "source_range": [
+            8951,
+            8975
+          ],
+          "rule": "§2.8 shared-input-param"
+        },
+        {
+          "output_range": [
+            9576,
+            9589
+          ],
+          "source_range": [
+            9042,
+            9068
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            9592,
+            9657
+          ],
+          "source_range": [
+            9071,
+            9071
+          ],
+          "rule": "§2.8 shared-input-receive"
+        },
+        {
+          "output_range": [
+            9673,
+            9690
+          ],
+          "source_range": [
+            9087,
+            9087
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            9736,
+            9749
+          ],
+          "source_range": [
+            9133,
+            9133
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            9934,
+            9971
+          ],
+          "source_range": [
+            9318,
+            9356
+          ],
+          "rule": "§2.3 in-sugar-param"
+        },
+        {
+          "output_range": [
+            10071,
+            10084
+          ],
+          "source_range": [
+            9456,
+            9482
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            10096,
+            10096
+          ],
+          "source_range": [
+            9494,
+            9507
+          ],
+          "rule": "§2.7 precondition-marker"
+        },
+        {
+          "output_range": [
+            10207,
+            10291
+          ],
+          "source_range": [
+            9618,
+            9618
+          ],
+          "rule": "§2.3 in-sugar-conversion"
+        },
+        {
+          "output_range": [
+            10307,
+            10324
+          ],
+          "source_range": [
+            9634,
+            9634
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            10373,
+            10386
+          ],
+          "source_range": [
+            9683,
+            9683
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            10491,
+            10518
+          ],
+          "source_range": [
+            9788,
+            9812
+          ],
+          "rule": "§2.8 shared-input-param"
+        },
+        {
+          "output_range": [
+            10585,
+            10598
+          ],
+          "source_range": [
+            9879,
+            9905
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            10601,
+            10666
+          ],
+          "source_range": [
+            9908,
+            9908
+          ],
+          "rule": "§2.8 shared-input-receive"
+        },
+        {
+          "output_range": [
+            10778,
+            10795
+          ],
+          "source_range": [
+            10020,
+            10020
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            10835,
+            10848
+          ],
+          "source_range": [
+            10060,
+            10060
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            13434,
+            13496
+          ],
+          "source_range": [
+            12646,
+            12683
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            13873,
-            13908
+            13506,
+            13541
           ],
           "source_range": [
-            13608,
-            13635
+            12693,
+            12720
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15100,
-            15129
+            14733,
+            14762
           ],
           "source_range": [
-            14827,
-            14848
+            13912,
+            13933
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15147,
-            15189
+            14780,
+            14822
           ],
           "source_range": [
-            14866,
-            14901
+            13951,
+            13986
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15207,
-            15266
+            14840,
+            14899
           ],
           "source_range": [
-            14919,
-            14968
+            14004,
+            14053
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15415,
-            15474
+            15048,
+            15107
           ],
           "source_range": [
-            15117,
-            15151
+            14202,
+            14236
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15722,
-            15750
+            15355,
+            15383
           ],
           "source_range": [
-            15399,
-            15420
+            14484,
+            14505
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15764,
-            15823
+            15397,
+            15456
           ],
           "source_range": [
-            15434,
-            15468
+            14519,
+            14553
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15837,
-            15888
+            15470,
+            15521
           ],
           "source_range": [
-            15482,
-            15525
+            14567,
+            14610
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            16250,
-            16299
+            15883,
+            15932
           ],
           "source_range": [
-            15887,
-            15928
+            14972,
+            15013
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            16451,
-            16502
+            16084,
+            16135
           ],
           "source_range": [
-            16080,
-            16123
+            15165,
+            15208
           ],
           "rule": "§4.1 operator-lowering"
         }

--- a/packages/difftest/contracts/generated-fherc20/.fhec/manifest.json
+++ b/packages/difftest/contracts/generated-fherc20/.fhec/manifest.json
@@ -9,606 +9,606 @@
       "mappings": [
         {
           "output_range": [
-            7439,
-            7476
+            7566,
+            7603
           ],
           "source_range": [
-            7439,
-            7465
+            7566,
+            7592
           ],
           "rule": "§2.3 in-sugar-param"
         },
         {
           "output_range": [
-            7476,
-            7501
+            7603,
+            7628
           ],
           "source_range": [
-            7465,
-            7465
+            7592,
+            7592
           ],
           "rule": "§2.3 in-sugar-proof-param"
         },
         {
           "output_range": [
-            7532,
-            7545
+            7659,
+            7672
           ],
           "source_range": [
-            7496,
-            7522
+            7623,
+            7649
           ],
           "rule": "§2.8 shared-return-type"
         },
         {
           "output_range": [
-            7548,
-            7632
+            7675,
+            7759
           ],
           "source_range": [
-            7525,
-            7525
+            7652,
+            7652
           ],
           "rule": "§2.3 in-sugar-conversion"
-        },
-        {
-          "output_range": [
-            7648,
-            7665
-          ],
-          "source_range": [
-            7541,
-            7541
-          ],
-          "rule": "§2.8 shared-return-share"
-        },
-        {
-          "output_range": [
-            7707,
-            7720
-          ],
-          "source_range": [
-            7583,
-            7583
-          ],
-          "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
             7775,
-            7802
+            7792
           ],
           "source_range": [
-            7638,
-            7662
+            7668,
+            7668
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            7834,
+            7847
+          ],
+          "source_range": [
+            7710,
+            7710
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            7902,
+            7929
+          ],
+          "source_range": [
+            7765,
+            7789
           ],
           "rule": "§2.8 shared-input-param"
         },
         {
           "output_range": [
-            7835,
-            7848
+            7962,
+            7975
           ],
           "source_range": [
-            7695,
-            7721
+            7822,
+            7848
           ],
           "rule": "§2.8 shared-return-type"
         },
         {
           "output_range": [
-            7851,
-            7916
+            7978,
+            8043
           ],
           "source_range": [
-            7724,
-            7724
+            7851,
+            7851
           ],
           "rule": "§2.8 shared-input-receive"
         },
         {
           "output_range": [
-            7932,
-            7949
+            8059,
+            8076
           ],
           "source_range": [
-            7740,
-            7740
+            7867,
+            7867
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            7982,
-            7995
+            8109,
+            8122
           ],
           "source_range": [
-            7773,
-            7773
+            7900,
+            7900
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            8173,
-            8210
+            8300,
+            8337
           ],
           "source_range": [
-            7951,
-            7977
+            8078,
+            8104
           ],
           "rule": "§2.3 in-sugar-param"
         },
         {
           "output_range": [
-            8215,
-            8240
+            8342,
+            8367
           ],
           "source_range": [
-            7982,
-            7982
+            8109,
+            8109
           ],
           "rule": "§2.3 in-sugar-proof-param"
         },
         {
           "output_range": [
-            8271,
-            8284
+            8398,
+            8411
           ],
           "source_range": [
-            8013,
-            8039
+            8140,
+            8166
           ],
           "rule": "§2.8 shared-return-type"
         },
         {
           "output_range": [
-            8296,
-            8296
+            8423,
+            8423
           ],
           "source_range": [
-            8051,
-            8064
-          ],
-          "rule": "§2.7 precondition-marker"
-        },
-        {
-          "output_range": [
-            8407,
-            8491
-          ],
-          "source_range": [
-            8175,
-            8175
-          ],
-          "rule": "§2.3 in-sugar-conversion"
-        },
-        {
-          "output_range": [
-            8507,
-            8524
-          ],
-          "source_range": [
-            8191,
+            8178,
             8191
           ],
-          "rule": "§2.8 shared-return-share"
+          "rule": "§2.7 precondition-marker"
         },
         {
           "output_range": [
-            8560,
-            8573
+            8534,
+            8618
           ],
           "source_range": [
-            8227,
-            8227
-          ],
-          "rule": "§2.8 shared-return-share"
-        },
-        {
-          "output_range": [
-            8671,
-            8698
-          ],
-          "source_range": [
-            8325,
-            8349
-          ],
-          "rule": "§2.8 shared-input-param"
-        },
-        {
-          "output_range": [
-            8736,
-            8749
-          ],
-          "source_range": [
-            8387,
-            8413
-          ],
-          "rule": "§2.8 shared-return-type"
-        },
-        {
-          "output_range": [
-            8752,
-            8817
-          ],
-          "source_range": [
-            8416,
-            8416
-          ],
-          "rule": "§2.8 shared-input-receive"
-        },
-        {
-          "output_range": [
-            8929,
-            8946
-          ],
-          "source_range": [
-            8528,
-            8528
-          ],
-          "rule": "§2.8 shared-return-share"
-        },
-        {
-          "output_range": [
-            8973,
-            8986
-          ],
-          "source_range": [
-            8555,
-            8555
-          ],
-          "rule": "§2.8 shared-return-share"
-        },
-        {
-          "output_range": [
-            9065,
-            9102
-          ],
-          "source_range": [
-            8634,
-            8672
-          ],
-          "rule": "§2.3 in-sugar-param"
-        },
-        {
-          "output_range": [
-            9202,
-            9215
-          ],
-          "source_range": [
-            8772,
-            8798
-          ],
-          "rule": "§2.8 shared-return-type"
-        },
-        {
-          "output_range": [
-            9218,
-            9302
-          ],
-          "source_range": [
-            8801,
-            8801
+            8302,
+            8302
           ],
           "rule": "§2.3 in-sugar-conversion"
         },
         {
           "output_range": [
-            9318,
-            9335
+            8634,
+            8651
           ],
           "source_range": [
-            8817,
-            8817
+            8318,
+            8318
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            9390,
-            9403
+            8687,
+            8700
           ],
           "source_range": [
-            8872,
-            8872
+            8354,
+            8354
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            9482,
-            9509
+            8798,
+            8825
           ],
           "source_range": [
-            8951,
-            8975
+            8452,
+            8476
           ],
           "rule": "§2.8 shared-input-param"
         },
         {
           "output_range": [
-            9576,
-            9589
+            8863,
+            8876
           ],
           "source_range": [
-            9042,
-            9068
+            8514,
+            8540
           ],
           "rule": "§2.8 shared-return-type"
         },
         {
           "output_range": [
-            9592,
-            9657
+            8879,
+            8944
           ],
           "source_range": [
-            9071,
-            9071
+            8543,
+            8543
           ],
           "rule": "§2.8 shared-input-receive"
         },
         {
           "output_range": [
-            9673,
-            9690
+            9056,
+            9073
           ],
           "source_range": [
-            9087,
-            9087
+            8655,
+            8655
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            9736,
-            9749
+            9100,
+            9113
           ],
           "source_range": [
-            9133,
-            9133
+            8682,
+            8682
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            9934,
-            9971
+            9192,
+            9229
           ],
           "source_range": [
-            9318,
-            9356
+            8761,
+            8799
           ],
           "rule": "§2.3 in-sugar-param"
         },
         {
           "output_range": [
-            10071,
-            10084
+            9329,
+            9342
           ],
           "source_range": [
-            9456,
-            9482
+            8899,
+            8925
           ],
           "rule": "§2.8 shared-return-type"
         },
         {
           "output_range": [
-            10096,
-            10096
+            9345,
+            9429
           ],
           "source_range": [
-            9494,
-            9507
+            8928,
+            8928
+          ],
+          "rule": "§2.3 in-sugar-conversion"
+        },
+        {
+          "output_range": [
+            9445,
+            9462
+          ],
+          "source_range": [
+            8944,
+            8944
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            9517,
+            9530
+          ],
+          "source_range": [
+            8999,
+            8999
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            9609,
+            9636
+          ],
+          "source_range": [
+            9078,
+            9102
+          ],
+          "rule": "§2.8 shared-input-param"
+        },
+        {
+          "output_range": [
+            9703,
+            9716
+          ],
+          "source_range": [
+            9169,
+            9195
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            9719,
+            9784
+          ],
+          "source_range": [
+            9198,
+            9198
+          ],
+          "rule": "§2.8 shared-input-receive"
+        },
+        {
+          "output_range": [
+            9800,
+            9817
+          ],
+          "source_range": [
+            9214,
+            9214
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            9863,
+            9876
+          ],
+          "source_range": [
+            9260,
+            9260
+          ],
+          "rule": "§2.8 shared-return-share"
+        },
+        {
+          "output_range": [
+            10061,
+            10098
+          ],
+          "source_range": [
+            9445,
+            9483
+          ],
+          "rule": "§2.3 in-sugar-param"
+        },
+        {
+          "output_range": [
+            10198,
+            10211
+          ],
+          "source_range": [
+            9583,
+            9609
+          ],
+          "rule": "§2.8 shared-return-type"
+        },
+        {
+          "output_range": [
+            10223,
+            10223
+          ],
+          "source_range": [
+            9621,
+            9634
           ],
           "rule": "§2.7 precondition-marker"
         },
         {
           "output_range": [
-            10207,
-            10291
+            10334,
+            10418
           ],
           "source_range": [
-            9618,
-            9618
+            9745,
+            9745
           ],
           "rule": "§2.3 in-sugar-conversion"
         },
         {
           "output_range": [
-            10307,
-            10324
+            10434,
+            10451
           ],
           "source_range": [
-            9634,
-            9634
+            9761,
+            9761
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            10373,
-            10386
+            10500,
+            10513
           ],
           "source_range": [
-            9683,
-            9683
+            9810,
+            9810
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            10491,
-            10518
+            10618,
+            10645
           ],
           "source_range": [
-            9788,
-            9812
+            9915,
+            9939
           ],
           "rule": "§2.8 shared-input-param"
         },
         {
           "output_range": [
-            10585,
-            10598
+            10712,
+            10725
           ],
           "source_range": [
-            9879,
-            9905
+            10006,
+            10032
           ],
           "rule": "§2.8 shared-return-type"
         },
         {
           "output_range": [
-            10601,
-            10666
+            10728,
+            10793
           ],
           "source_range": [
-            9908,
-            9908
+            10035,
+            10035
           ],
           "rule": "§2.8 shared-input-receive"
         },
         {
           "output_range": [
-            10778,
-            10795
+            10905,
+            10922
           ],
           "source_range": [
-            10020,
-            10020
+            10147,
+            10147
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            10835,
-            10848
+            10962,
+            10975
           ],
           "source_range": [
-            10060,
-            10060
+            10187,
+            10187
           ],
           "rule": "§2.8 shared-return-share"
         },
         {
           "output_range": [
-            13434,
-            13496
+            13561,
+            13623
           ],
           "source_range": [
-            12646,
-            12683
+            12773,
+            12810
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            13506,
-            13541
+            13633,
+            13668
           ],
           "source_range": [
-            12693,
-            12720
+            12820,
+            12847
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            14733,
-            14762
+            14860,
+            14889
           ],
           "source_range": [
-            13912,
-            13933
+            14039,
+            14060
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            14780,
-            14822
+            14907,
+            14949
           ],
           "source_range": [
-            13951,
-            13986
+            14078,
+            14113
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            14840,
-            14899
+            14967,
+            15026
           ],
           "source_range": [
-            14004,
-            14053
+            14131,
+            14180
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15048,
-            15107
+            15175,
+            15234
           ],
           "source_range": [
-            14202,
-            14236
+            14329,
+            14363
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15355,
-            15383
+            15482,
+            15510
           ],
           "source_range": [
-            14484,
-            14505
+            14611,
+            14632
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15397,
-            15456
+            15524,
+            15583
           ],
           "source_range": [
-            14519,
-            14553
+            14646,
+            14680
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15470,
-            15521
+            15597,
+            15648
           ],
           "source_range": [
-            14567,
-            14610
+            14694,
+            14737
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            15883,
-            15932
+            16010,
+            16059
           ],
           "source_range": [
-            14972,
-            15013
+            15099,
+            15140
           ],
           "rule": "§4.1 operator-lowering"
         },
         {
           "output_range": [
-            16084,
-            16135
+            16211,
+            16262
           ],
           "source_range": [
-            15165,
-            15208
+            15292,
+            15335
           ],
           "rule": "§4.1 operator-lowering"
         }

--- a/packages/difftest/contracts/generated-fherc20/FHERC20.sol
+++ b/packages/difftest/contracts/generated-fherc20/FHERC20.sol
@@ -25,17 +25,17 @@ import {
  * the ERC-7201 namespaced struct (the upgradeable, namespaced-storage variant
  * stays with the plain-Solidity reference).
  *
- * What the dialect removes relative to the reference:
- * - `externalEuint64` + `bytes inputProof` parameter pairs and their
- *   `FHE.asEuint64(hash, proof)` verification calls become `in euint64`
- *   parameters (`confidentialTransfer`, `confidentialTransferFrom`);
+ * Dialect syntax used below:
+ * - ordinary external inputs use `in euint64`; positioned-proof inputs use
+ *   `in(inputProof) euint64`;
+ * - shared inputs use `in shared euint64`, and directed shared outputs use
+ *   `shared(msg.sender) euint64`;
+ * - a `precondition` block runs before input proof verification, so the
+ *   operator check keeps its upstream position in the From overloads;
  * - the {FHESafeMath} library disappears: its checked arithmetic is written
  *   inline in `_update` with encrypted operators (`+`, `-`, `>=`) and
  *   encrypted ternaries (`cond ? a : b`), which lower to `FHE.add`/`FHE.sub`/
  *   `FHE.gte`/`FHE.select`;
- * - the AndCall variants keep the explicit external+proof form on purpose:
- *   ERC-7984 fixes their parameter order as (…, encryptedAmount, inputProof,
- *   data), while the sugar always appends the proof last.
  *
  * ACL policy stays fully explicit (this project builds with `acl.mode =
  * "suggest"`): FHERC20 grants balance handles to the affected account, not to
@@ -176,84 +176,80 @@ contract FHERC20 is IFHERC20, ERC165, ReentrancyGuardTransient {
     /// (address to, externalEuint64 encryptedAmount, bytes inputProof).
     function confidentialTransfer(address to, externalEuint64 encryptedAmount_input, bytes memory inputProof) public nonReentrant returns (sharedEuint64) {
         euint64 encryptedAmount = FHE.asEuint64(encryptedAmount_input, inputProof);
-        euint64 transferred = _transfer(msg.sender, to, encryptedAmount);
-        return FHE.shareEuint64(transferred, msg.sender);
+        return FHE.shareEuint64(_transfer(msg.sender, to, encryptedAmount), msg.sender);
     }
 
-    function confidentialTransfer(address to, sharedEuint64 sharedAmount) public nonReentrant returns (sharedEuint64) {
-        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
-        euint64 transferred = _transfer(msg.sender, to, amount);
-        return FHE.shareEuint64(transferred, msg.sender);
+    function confidentialTransfer(address to, sharedEuint64 amount_shared) external nonReentrant returns (sharedEuint64) {
+        euint64 amount = FHE.receiveEuint64Param(amount_shared);
+        return FHE.shareEuint64(_transfer(msg.sender, to, amount), msg.sender);
     }
 
-    /// @dev `in euint64` sugar; lowered signature matches ERC-7984.
+    /// @dev A precondition preserves operator-check-before-proof-verification.
     function confidentialTransferFrom(
         address from,
         address to,
         externalEuint64 encryptedAmount_input
     , bytes memory inputProof) public nonReentrant returns (sharedEuint64) {
+        {
+            if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+        }
         euint64 encryptedAmount = FHE.asEuint64(encryptedAmount_input, inputProof);
-        if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        euint64 transferred = _transfer(from, to, encryptedAmount);
-        return FHE.shareEuint64(transferred, msg.sender);
+        return FHE.shareEuint64(_transfer(from, to, encryptedAmount), msg.sender);
     }
 
     function confidentialTransferFrom(
         address from,
         address to,
-        sharedEuint64 sharedAmount
-    ) public nonReentrant returns (sharedEuint64) {
-        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
+        sharedEuint64 amount_shared
+    ) external nonReentrant returns (sharedEuint64) {
+        euint64 amount = FHE.receiveEuint64Param(amount_shared);
         if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        euint64 transferred = _transfer(from, to, amount);
-        return FHE.shareEuint64(transferred, msg.sender);
-    }
-
-    /// @dev No sugar here: ERC-7984 fixes the order (…, inputProof, data),
-    /// while the `in` sugar always appends the proof as the LAST parameter.
-    function confidentialTransferAndCall(
-        address to,
-        externalEuint64 encryptedAmount,
-        bytes calldata inputProof,
-        bytes calldata data
-    ) public nonReentrant returns (sharedEuint64) {
-        euint64 transferred = _transferAndCall(msg.sender, to, FHE.asEuint64(encryptedAmount, inputProof), data);
-        return FHE.shareEuint64(transferred, msg.sender);
+        return FHE.shareEuint64(_transfer(from, to, amount), msg.sender);
     }
 
     function confidentialTransferAndCall(
         address to,
-        sharedEuint64 sharedAmount,
-        bytes calldata data
-    ) public nonReentrant returns (sharedEuint64) {
-        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
-        euint64 transferred = _transferAndCall(msg.sender, to, amount, data);
-        return FHE.shareEuint64(transferred, msg.sender);
-    }
-
-    /// @dev No sugar: see {confidentialTransferAndCall}.
-    function confidentialTransferFromAndCall(
-        address from,
-        address to,
-        externalEuint64 encryptedAmount,
+        externalEuint64 encryptedAmount_input,
         bytes calldata inputProof,
         bytes calldata data
     ) public nonReentrant returns (sharedEuint64) {
-        if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        euint64 transferred = _transferAndCall(from, to, FHE.asEuint64(encryptedAmount, inputProof), data);
-        return FHE.shareEuint64(transferred, msg.sender);
+        euint64 encryptedAmount = FHE.asEuint64(encryptedAmount_input, inputProof);
+        return FHE.shareEuint64(_transferAndCall(msg.sender, to, encryptedAmount, data), msg.sender);
+    }
+
+    function confidentialTransferAndCall(
+        address to,
+        sharedEuint64 amount_shared,
+        bytes calldata data
+    ) external nonReentrant returns (sharedEuint64) {
+        euint64 amount = FHE.receiveEuint64Param(amount_shared);
+        return FHE.shareEuint64(_transferAndCall(msg.sender, to, amount, data), msg.sender);
+    }
+
+    /// @dev A precondition preserves operator-check-before-proof-verification.
+    function confidentialTransferFromAndCall(
+        address from,
+        address to,
+        externalEuint64 encryptedAmount_input,
+        bytes calldata inputProof,
+        bytes calldata data
+    ) public nonReentrant returns (sharedEuint64) {
+        {
+            if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+        }
+        euint64 encryptedAmount = FHE.asEuint64(encryptedAmount_input, inputProof);
+        return FHE.shareEuint64(_transferAndCall(from, to, encryptedAmount, data), msg.sender);
     }
 
     function confidentialTransferFromAndCall(
         address from,
         address to,
-        sharedEuint64 sharedAmount,
+        sharedEuint64 amount_shared,
         bytes calldata data
-    ) public nonReentrant returns (sharedEuint64) {
-        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
+    ) external nonReentrant returns (sharedEuint64) {
+        euint64 amount = FHE.receiveEuint64Param(amount_shared);
         if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        euint64 transferred = _transferAndCall(from, to, amount, data);
-        return FHE.shareEuint64(transferred, msg.sender);
+        return FHE.shareEuint64(_transferAndCall(from, to, amount, data), msg.sender);
     }
 
     // =========================================================================

--- a/packages/difftest/contracts/generated-fherc20/FHERC20.sol
+++ b/packages/difftest/contracts/generated-fherc20/FHERC20.sol
@@ -31,7 +31,9 @@ import {
  * - shared inputs use `in shared euint64`, and directed shared outputs use
  *   `shared(msg.sender) euint64`;
  * - a `precondition` block runs before input proof verification, so the
- *   operator check keeps its upstream position in the From overloads;
+ *   operator check keeps its upstream position in the proof-taking From
+ *   functions; the shared-input From overloads stay receive-first, matching
+ *   upstream, since they never verify a proof;
  * - the {FHESafeMath} library disappears: its checked arithmetic is written
  *   inline in `_update` with encrypted operators (`+`, `-`, `>=`) and
  *   encrypted ternaries (`cond ? a : b`), which lower to `FHE.add`/`FHE.sub`/

--- a/packages/difftest/scenarios/fherc20.ts
+++ b/packages/difftest/scenarios/fherc20.ts
@@ -386,8 +386,14 @@ export function makeFherc20SharedScenario(wiring: SharedWiring): Scenario {
   };
 }
 
-/** The one known PR #26 baseline divergence: basic external From is proof-first only on generated output. */
-export function makeFherc20ExpectedDivergenceScenario(wiring: Fherc20Accounts): Scenario {
+/**
+ * Basic external From with BOTH an unauthorized operator and a proof bound to
+ * the wrong consumer. The order of the two failures is observable, so this
+ * pinned the one old baseline divergence: generated output used to verify the
+ * proof first and report `InvalidSigner`. A `precondition` block now keeps the
+ * operator check first, and both sides report `FHERC20UnauthorizedSpender`.
+ */
+export function makeFherc20CompoundInvalidOrderingScenario(wiring: Fherc20Accounts): Scenario {
   return {
     name: 'FHERC20 basic From unauthorized plus wrong-consumer proof ordering',
     steps: [

--- a/packages/difftest/scenarios/fherc20.ts
+++ b/packages/difftest/scenarios/fherc20.ts
@@ -97,7 +97,8 @@ async function balanceHandleArg(ctx: StepContext, account: string): Promise<unkn
 /**
  * Strict external-input/operator/ACL coverage. This includes valid, self,
  * unauthorized, and expired operators, plus the operator-first compound-invalid
- * FromAndCall path. The basic known ordering divergence is isolated elsewhere.
+ * FromAndCall path. The basic From compound-invalid ordering case is isolated
+ * elsewhere (also strict — no divergence remains).
  */
 export function makeFherc20CoreScenario(wiring: Fherc20Accounts): Scenario {
   return {
@@ -392,6 +393,11 @@ export function makeFherc20SharedScenario(wiring: SharedWiring): Scenario {
  * pinned the one old baseline divergence: generated output used to verify the
  * proof first and report `InvalidSigner`. A `precondition` block now keeps the
  * operator check first, and both sides report `FHERC20UnauthorizedSpender`.
+ *
+ * A second step repeats the wrong-consumer proof with an AUTHORIZED operator,
+ * so the precondition passes and proof verification is actually reached. This
+ * proves the ordering test isn't tautological: the operator check firing
+ * first in step 0 isn't masking a proof check that would always pass anyway.
  */
 export function makeFherc20CompoundInvalidOrderingScenario(wiring: Fherc20Accounts): Scenario {
   return {
@@ -403,6 +409,18 @@ export function makeFherc20CompoundInvalidOrderingScenario(wiring: Fherc20Accoun
         label: 'unauthorized basic From with proof bound to wrong consumer',
         args: (ctx) => wrongConsumerArgs(ctx, 1n, wiring.dave, [wiring.alice, wiring.carol]),
         expectRevert: true,
+      },
+      {
+        fn: 'setOperator',
+        label: 'alice authorizes carol as operator',
+        args: [wiring.carol, OPERATOR_UNTIL],
+      },
+      {
+        fn: 'confidentialTransferFrom(address,address,bytes32,bytes)',
+        from: 2,
+        label: 'authorized basic From still fails on a proof bound to the wrong consumer',
+        args: (ctx) => wrongConsumerArgs(ctx, 1n, wiring.dave, [wiring.alice, wiring.carol]),
+        expectRevert: 'InvalidSigner',
       },
     ],
     probeAfterEachStep: false,

--- a/packages/difftest/test/fherc20.diff.test.ts
+++ b/packages/difftest/test/fherc20.diff.test.ts
@@ -6,7 +6,6 @@ import { expect } from 'chai';
 import { deployMockEnvironment, type MockEnvironment } from '../src/mocks';
 import {
   assertDifferentiallyEquivalent,
-  runDifferential,
   type DifferentialResult,
   type RunResult,
   type Scenario,
@@ -20,8 +19,8 @@ import {
   OPERATOR_UNTIL,
   makeFherc20ArithmeticScenario,
   makeFherc20CallbackScenario,
+  makeFherc20CompoundInvalidOrderingScenario,
   makeFherc20CoreScenario,
-  makeFherc20ExpectedDivergenceScenario,
   makeFherc20SharedScenario,
   type Fherc20Accounts,
 } from '../scenarios/fherc20';
@@ -94,9 +93,10 @@ async function deployTokenPair(): Promise<{ reference: Contract; generated: Cont
 
 /**
  * The flagship pair is the current fhec output versus the unmodified upstream
- * FHERC20. Strict scenarios compare plaintexts, ACL, indicators, and revert
- * identity without comparing ciphertext handles. One baseline ordering gap is
- * characterized separately and remains a real compareRuns divergence.
+ * FHERC20. Every scenario is strict: it compares plaintexts, ACL, indicators,
+ * and revert identity without comparing ciphertext handles. No divergence
+ * remains — the `precondition` block closed the last ordering gap, so all eight
+ * transfer overloads now agree on error identity as well as on effect.
  */
 describe('differential :: transpiled FHERC20 (dialect) vs upstream fhenix-confidential-contracts', () => {
   let env: MockEnvironment;
@@ -343,34 +343,21 @@ describe('differential :: transpiled FHERC20 (dialect) vs upstream fhenix-confid
     expect(final.values.driverIsOperator).to.equal('true');
   });
 
-  it('characterizes exactly the one basic From compound-invalid ordering divergence', async function () {
+  it('matches basic From compound-invalid ordering, operator error first on both sides', async function () {
     this.timeout(240_000);
     const { reference, generated } = await deployTokenPair();
-    const scenario = makeFherc20ExpectedDivergenceScenario(accounts);
-    const result = await runDifferential(env, reference, generated, scenario, {
+    const scenario = makeFherc20CompoundInvalidOrderingScenario(accounts);
+    const result = await assertDifferentiallyEquivalent(env, reference, generated, scenario, {
       labelA: LABELS.a,
       labelB: LABELS.b,
     });
 
-    expect(result.equivalent).to.equal(false);
-    expect(result.a.steps).to.have.length(1);
-    expect(result.b.steps).to.have.length(1);
-    expect(result.a.steps[0].expectationMet).to.equal(true);
-    expect(result.b.steps[0].expectationMet).to.equal(true);
+    assertStrictResult(result, scenario, { plaintexts: [], acl: [], values: [] });
+
+    // The `precondition` block keeps the operator check ahead of proof
+    // verification, so both sides report the operator error, not `InvalidSigner`.
     expect(result.a.steps[0].revertKey).to.equal('FHERC20UnauthorizedSpender');
-    expect(result.b.steps[0].revertKey).to.equal('InvalidSigner');
-    expect(result.divergences).to.have.length(1);
-    expect(result.divergences[0]).to.include({
-      kind: 'revert',
-      where: 'step 0 (unauthorized basic From with proof bound to wrong consumer)',
-      message: 'both reverted, but with different errors',
-    });
-    expect(result.divergences[0].a).to.include('FHERC20UnauthorizedSpender');
-    expect(result.divergences[0].b).to.include('InvalidSigner');
-    expect(result.a.snapshots.map((snapshot) => snapshot.after)).to.deep.equal([
-      'initial',
-      'step 0 (unauthorized basic From with proof bound to wrong consumer)',
-    ]);
+    expect(result.b.steps[0].revertKey).to.equal('FHERC20UnauthorizedSpender');
     expect(result.a.snapshots[0].plaintexts).to.deep.equal({});
     expect(result.a.snapshots[0].acl).to.deep.equal({});
     expect(result.a.snapshots[0].values).to.deep.equal({});

--- a/packages/difftest/test/fherc20.diff.test.ts
+++ b/packages/difftest/test/fherc20.diff.test.ts
@@ -361,6 +361,13 @@ describe('differential :: transpiled FHERC20 (dialect) vs upstream fhenix-confid
     expect(result.a.snapshots[0].plaintexts).to.deep.equal({});
     expect(result.a.snapshots[0].acl).to.deep.equal({});
     expect(result.a.snapshots[0].values).to.deep.equal({});
+
+    // Step 2 repeats the wrong-consumer proof with an authorized operator, so
+    // the precondition passes and proof verification is actually reached.
+    // Both sides must still report `InvalidSigner` — this is what proves step
+    // 0's operator-first ordering isn't hiding a proof check that never runs.
+    expect(result.a.steps[2].revertKey).to.equal('InvalidSigner');
+    expect(result.b.steps[2].revertKey).to.equal('InvalidSigner');
   });
 
   it('pins the canonical eight-transfer ABI, selectors, surface, and interface support', async function () {


### PR DESCRIPTION
## What this does

Phase 4 of `scratch/fherc20-comparison/IMPLEMENTATION_PLAN.md` — the final phase. Replaces the tracked FHERC20 dialect source's 8 transfer-API functions with the approved `precondition`-based mockup, and tightens the one previously-expected differential divergence to strict equivalence (the compiler bug that caused it is now fixed).

Stacked on #41 (Phase 3) → #37 (Phase 2) → #36 (Phase 1). This PR's base is `feat/shared-boundary`; diff here is Phase 4 only.

## A real blocker found and fixed along the way

The first attempt at this phase found `precondition`'s `msg.sender` guard (spec §2.7 explicitly permits it) was refused with FHE3015 whenever the contract inherits from any base the binder can't fully resolve — which is every real contract that inherits from OpenZeppelin or an interface package, i.e. exactly FHERC20's own case, and the whole reason this feature exists. Root cause: the checker judged `msg`'s resolution directly but never followed `Resolution::Unresolved(IncompleteInheritance { fallback, .. })` down to its fallback, unlike the existing (and correct) handling for the same problem with the `FHE` library name in `trust.rs`. Fixed at the source on `feat/precondition` (mirroring `trust.rs`'s existing, documented judgment call) and merged forward through every branch in the stack, including this one — see the merge commits in this branch's history.

## Source-call counts (plan §12) — all confirmed

2 `precondition` blocks (the two proof-taking `From` overloads), 0 source `FHE.asEuint64`/`FHE.share*`/`FHE.receive*` in transfer APIs, 6 storage-ACL statements and 3 local-result-ACL statements in `_update` (unchanged). The shared-input overloads keep their inline operator check with no `precondition`, preserving `receiveETParam → operator check → body`. `FromAndCall`'s already-strict operator-first order is unchanged.

## One deviation, already reviewed and approved in #41

The mockup declares its 4 `in shared` input overloads `public`; Phase 3's review found and fixed a real bug where that breaks internal call sites, narrowing the MVP to `external`-only. Changed to `external` here — safe (no internal callers, ABI/selector-preserving, confirmed by review).

## Review

One round (codex): confirmed the `public`→`external` change is safe and the generated output has no drift, but flagged the rewritten strict-equivalence test as not proving the proof-check itself still works (only that the operator check fires first) — a future regression could make the ordering test pass tautologically. Added a companion step: same wrong-consumer proof, but with an *authorized* operator, confirming both sides still hit `InvalidSigner`. Also corrected two stale comments describing an ordering divergence that no longer exists.

## Test plan

- [x] `cargo build -p fhec-cli`
- [x] `fhec --config packages/difftest/fhec.fherc20.toml build --json --self-check` / `--frozen`
- [x] `pnpm --filter difftest run build:dialect`
- [x] `pnpm --filter difftest test` — 13/13 passing, no expected divergence anywhere in the suite
- [x] `pnpm --filter difftest run check:types`
- [x] `cargo test --workspace`