### PR TITLE
chore: treat .fsol files as Solidity in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.fsol": "solidity"
+  }
+}


### PR DESCRIPTION
## What this does

Adds `.vscode/settings.json` mapping `*.fsol` to the `solidity` language mode. `.fsol` is a strict superset of Solidity grammar, so this gets full syntax highlighting from whatever Solidity extension is already installed, with zero custom tooling.

Useful right now for reading the new `FHERC20.fsol` in #42.

## Tradeoff

The dialect-specific keywords (`precondition`, `in shared`, `shared(...)`) will read as ordinary identifiers — they won't visually stand out from the rest of the source. If that's wanted later, a small TextMate grammar injection extending the base Solidity grammar would get there without a full extension/LSP.