### PR TITLE
fix(cli): make the build output readable and the rename recoverable

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,7 +1,9 @@
 # Writing `.fsol`
 
 `.fsol` is Solidity plus six shortcuts for CoFHE. Every valid Solidity file is
-already a valid `.fsol` file — adopt it one function at a time. `fhec build`
+already a valid `.fsol` file — adopt it one function at a time. Rename a file
+to `.fsol` to opt it in; `fhec check --fix` rewrites relative imports that
+still end in `.sol` when the target was discovered as `.fsol`. `fhec build`
 compiles it down to the plain, auditable Solidity you'd otherwise write by
 hand; see [README.md](README.md) for setup and the CLI.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ preserved byte-for-byte — comments, formatting, everything.
 | `--fix` | Apply safe fix-its to the source |
 | `--acl=insert\|suggest` | Insert ACL grants (default) or downgrade them to fix-it notes |
 | `--no-verify` | Skip the solc gate |
+| `--all-solc-warnings` | Forward solc warnings from files outside `project.src` (suppressed by default; errors from any file still come through) |
 | `--watch` | Rebuild or recheck when dialect sources or `fhec.toml` change (`build` / `check` only) |
 
 Diagnostics carry stable codes (`FHE1xxx` load/parse … `FHE9xxx` internal),

--- a/crates/fhec-cli/src/commands.rs
+++ b/crates/fhec-cli/src/commands.rs
@@ -29,6 +29,8 @@ pub struct GlobalArgs {
     pub self_check: bool,
     /// Rebuild or recheck when dialect sources or `fhec.toml` change.
     pub watch: bool,
+    /// Forward non-error solc diagnostics from files outside `project.src`.
+    pub all_solc_warnings: bool,
 }
 
 impl GlobalArgs {
@@ -127,7 +129,9 @@ pub fn cmd_check(g: &GlobalArgs) -> i32 {
     let mut diags = pre_diags;
     diags.extend(result.diagnostics);
     let code = finish(&diags, &loaded, &unit, g);
-    if code == 0 && g.verbose {
+    // Human `check` always prints this line so a clean run is distinct from
+    // "found nothing to do". `--json` stays silent (spec §10.2 array only).
+    if code == 0 && !g.json {
         eprintln!(
             "fhec: {} file(s) checked clean, {} rewrite site(s) (config hash {})",
             unit.files.len(),
@@ -255,11 +259,11 @@ pub fn cmd_build(g: &GlobalArgs) -> i32 {
         if !g.no_verify {
             diags.extend(crate::gate::run_gate(
                 &loaded.root,
-                &loaded.config.project.out,
                 &result.outputs,
                 &manifest,
                 &unit,
-                &loaded.config.target,
+                &loaded.config,
+                g.all_solc_warnings,
             ));
         }
         return finish(&diags, &loaded, &unit, g);
@@ -321,11 +325,11 @@ pub fn cmd_build(g: &GlobalArgs) -> i32 {
     if !g.no_verify {
         let gate_diags = crate::gate::run_gate(
             &loaded.root,
-            &loaded.config.project.out,
             &result.outputs,
             &manifest,
             &unit,
-            &loaded.config.target,
+            &loaded.config,
+            g.all_solc_warnings,
         );
         diags.extend(gate_diags);
     } else if g.verbose {

--- a/crates/fhec-cli/src/explain.rs
+++ b/crates/fhec-cli/src/explain.rs
@@ -17,10 +17,11 @@ pub struct CatalogEntry {
 pub static CATALOG: &[CatalogEntry] = &[
     CatalogEntry { code: "FHE1001", severity: "error", name: "unsupported-pragma-range", rule: "§2.1", summary: "The file's pragma solidity range is not within >=0.8.25 <0.9.0." },
     CatalogEntry { code: "FHE1002", severity: "error", name: "dialect-parse-error", rule: "§2.2", summary: "The source does not parse under the .fsol dialect grammar." },
-    CatalogEntry { code: "FHE1003", severity: "error", name: "import-not-found", rule: "§2.2", summary: "An import specifier cannot be resolved." },
+    CatalogEntry { code: "FHE1003", severity: "error", name: "import-not-found", rule: "§2.2", summary: "An import specifier cannot be resolved. A relative .sol/.fsol swap that names a discovered unit file carries a safe fix-it." },
     CatalogEntry { code: "FHE1004", severity: "error", name: "config-not-found (draft)", rule: "—", summary: "No fhec.toml was found upward from the working directory (draft code, pending spec §9 inclusion)." },
     CatalogEntry { code: "FHE1005", severity: "error", name: "config-invalid (draft)", rule: "—", summary: "fhec.toml is unreadable or invalid (draft code, pending spec §9 inclusion)." },
     CatalogEntry { code: "FHE1006", severity: "error", name: "frozen-drift (draft)", rule: "§1.4", summary: "--frozen: regenerating the out dir would change it; run `fhec build` and commit (draft code, pending spec §9 inclusion)." },
+    CatalogEntry { code: "FHE1007", severity: "warning", name: "no-files-matched", rule: "§2.1", summary: "project.include matched no .fsol/.sol files under project.src; this is almost always a misconfigured src or include glob." },
     CatalogEntry { code: "FHE1020", severity: "error", name: "duplicate-definition", rule: "§9", summary: "The same name is declared twice in one scope." },
     CatalogEntry { code: "FHE1010", severity: "error", name: "in-sugar-non-encrypted-type", rule: "§2.3", summary: "`in` parameter sugar used with a type that is not an encrypted value type." },
     CatalogEntry { code: "FHE1011", severity: "error", name: "in-sugar-name-collision", rule: "§2.3", summary: "The generated `<name>_input` identifier collides with an existing declaration." },

--- a/crates/fhec-cli/src/gate.rs
+++ b/crates/fhec-cli/src/gate.rs
@@ -6,7 +6,7 @@
 //! with spans remapped through the manifest onto the original `.fsol`
 //! positions.
 
-use crate::config::Target;
+use crate::config::Config;
 use crate::diag::{Diagnostic, Severity, Span};
 use crate::load::LoadedUnit;
 use crate::stages::{resolve_relative, FileOutput};
@@ -20,16 +20,52 @@ const INSTALL_HINT: &str =
     "install the library packages (e.g. `npm install @fhenixprotocol/cofhe-contracts` or \
      `pnpm add @fhenixprotocol/cofhe-contracts`), or pass --no-verify to skip the solc gate";
 
+/// True when a remapped solc span names a file under `project.src`.
+///
+/// Discovered unit files are stored as paths relative to `src`, so a match on
+/// `rel_path` counts. A path that is `src` itself or is prefixed by `src/` also
+/// counts. Bare specifiers such as `@openzeppelin/contracts/...` do not.
+pub(crate) fn solc_file_in_src(file: &str, unit: &LoadedUnit, src: &str) -> bool {
+    if unit.files.iter().any(|f| f.rel_path == file) {
+        return true;
+    }
+    let src = src.trim_end_matches('/');
+    if src.is_empty() {
+        return false;
+    }
+    file == src || file.starts_with(&format!("{src}/"))
+}
+
+/// Whether a forwarded solc diagnostic should be reported.
+///
+/// Errors from any file always pass through. Non-errors from outside
+/// `project.src` are suppressed unless `all_solc_warnings` is set.
+pub(crate) fn keep_forwarded_solc(
+    severity: Severity,
+    file: &str,
+    unit: &LoadedUnit,
+    src: &str,
+    all_solc_warnings: bool,
+) -> bool {
+    severity == Severity::Error || all_solc_warnings || solc_file_in_src(file, unit, src)
+}
+
 /// Runs the gate over the emitted outputs. Returns diagnostics; an empty
 /// list means the gate passed.
+///
+/// Non-error FHE6000 diagnostics whose file is outside `project.src` are
+/// dropped unless `all_solc_warnings` is true. Errors from any file are kept.
 pub fn run_gate(
     root: &Path,
-    out_dir_name: &str,
     outputs: &[FileOutput],
     manifest: &Manifest,
     unit: &LoadedUnit,
-    target: &Target,
+    config: &Config,
+    all_solc_warnings: bool,
 ) -> Vec<Diagnostic> {
+    let out_dir_name = config.project.out.as_str();
+    let src = config.project.src.as_str();
+    let target = &config.target;
     let mut diags = Vec::new();
 
     // 1. Source closure.
@@ -108,6 +144,9 @@ pub fn run_gate(
                 .push_str(" (position is inside code fhec generated from this construct)");
         }
         d.rule = vd.rule.clone();
+        if !keep_forwarded_solc(severity, &d.span.file, unit, src, all_solc_warnings) {
+            continue;
+        }
         diags.push(d);
     }
     diags
@@ -364,5 +403,78 @@ mod tests {
                 "./C.sol".to_string()
             ]
         );
+    }
+
+    fn unit_with(rel: &str) -> LoadedUnit {
+        LoadedUnit {
+            files: vec![crate::load::SourceFile {
+                rel_path: rel.into(),
+                abs_path: PathBuf::from(rel),
+                content: String::new(),
+                dialect: crate::load::Dialect::Sol,
+            }],
+        }
+    }
+
+    #[test]
+    fn src_warnings_are_kept_and_third_party_warnings_are_dropped() {
+        let unit = unit_with("Vault.fsol");
+        assert!(solc_file_in_src("Vault.fsol", &unit, "contracts"));
+        assert!(solc_file_in_src("contracts/Vault.fsol", &unit, "contracts"));
+        assert!(!solc_file_in_src(
+            "@openzeppelin/contracts/utils/TransientSlot.sol",
+            &unit,
+            "contracts"
+        ));
+        // A third-party path that merely contains the src directory name
+        // must not count as in-src.
+        assert!(!solc_file_in_src(
+            "@openzeppelin/contracts/token/ERC20/ERC20.sol",
+            &unit,
+            "contracts"
+        ));
+
+        assert!(keep_forwarded_solc(
+            Severity::Warning,
+            "Vault.fsol",
+            &unit,
+            "contracts",
+            false
+        ));
+        assert!(!keep_forwarded_solc(
+            Severity::Warning,
+            "@openzeppelin/contracts/utils/TransientSlot.sol",
+            &unit,
+            "contracts",
+            false
+        ));
+        assert!(keep_forwarded_solc(
+            Severity::Error,
+            "@openzeppelin/contracts/utils/TransientSlot.sol",
+            &unit,
+            "contracts",
+            false
+        ));
+        assert!(keep_forwarded_solc(
+            Severity::Warning,
+            "@openzeppelin/contracts/utils/TransientSlot.sol",
+            &unit,
+            "contracts",
+            true
+        ));
+        assert!(keep_forwarded_solc(
+            Severity::Note,
+            "Vault.fsol",
+            &unit,
+            "contracts",
+            false
+        ));
+        assert!(!keep_forwarded_solc(
+            Severity::Note,
+            "noisy/Lib.sol",
+            &unit,
+            "contracts",
+            false
+        ));
     }
 }

--- a/crates/fhec-cli/src/load.rs
+++ b/crates/fhec-cli/src/load.rs
@@ -1,6 +1,6 @@
 //! Stage 1 (Load): file discovery and compilation-unit assembly.
 
-use crate::config::{Config, CODE_CONFIG_INVALID};
+use crate::config::{Config, CODE_CONFIG_INVALID, CONFIG_FILE_NAME};
 use crate::diag::{Diagnostic, Severity, Span};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use std::path::{Path, PathBuf};
@@ -30,6 +30,9 @@ pub struct SourceFile {
 pub struct LoadedUnit {
     pub files: Vec<SourceFile>,
 }
+
+/// Warning: `project.include` matched no `.fsol` / `.sol` files under `project.src`.
+pub const CODE_NO_FILES_MATCHED: &str = "FHE1007";
 
 fn glob_set(patterns: &[String], what: &str) -> Result<GlobSet, Box<Diagnostic>> {
     let mut b = GlobSetBuilder::new();
@@ -132,6 +135,19 @@ pub fn discover(
             dialect,
         });
     }
+    if files.is_empty() {
+        let mut d = Diagnostic::new(
+            CODE_NO_FILES_MATCHED,
+            Severity::Warning,
+            Span::file_level(CONFIG_FILE_NAME),
+            format!(
+                "no source files matched project.include under `{}` (include = {:?})",
+                config.project.src, config.project.include
+            ),
+        );
+        d.rule = Some("§2.1".to_string());
+        diags.push(d);
+    }
     Ok(LoadedUnit { files })
 }
 
@@ -215,5 +231,19 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let err = discover(&Config::default(), tmp.path(), &mut Vec::new()).unwrap_err();
         assert_eq!(err.code, CODE_CONFIG_INVALID);
+    }
+
+    #[test]
+    fn empty_src_warns_no_files_matched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("contracts")).unwrap();
+        let mut diags = Vec::new();
+        let unit = discover(&Config::default(), root, &mut diags).unwrap();
+        assert!(unit.files.is_empty());
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, CODE_NO_FILES_MATCHED);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert!(diags[0].message.contains("project.include"));
     }
 }

--- a/crates/fhec-cli/src/main.rs
+++ b/crates/fhec-cli/src/main.rs
@@ -38,6 +38,10 @@ struct Cli {
     #[arg(long, global = true)]
     no_verify: bool,
 
+    /// Also forward non-error solc diagnostics from files outside project.src.
+    #[arg(long, global = true)]
+    all_solc_warnings: bool,
+
     /// Re-transpile the generated output and assert byte identity (spec §1.4).
     #[arg(long, global = true, hide = true)]
     self_check: bool,
@@ -90,6 +94,7 @@ fn main() {
         no_verify: cli.no_verify,
         self_check: cli.self_check,
         watch: cli.watch,
+        all_solc_warnings: cli.all_solc_warnings,
     };
     let code = match cli.command {
         Command::Build if g.watch => fhec_cli::watch::cmd_watch(&g, commands::cmd_build),

--- a/crates/fhec-cli/src/stages.rs
+++ b/crates/fhec-cli/src/stages.rs
@@ -179,6 +179,7 @@ pub fn run(unit: &LoadedUnit, config: &Config, opts: &StageOptions) -> StagesRes
                 d.message.clone(),
             );
             diag.rule = Some("§2.2".to_string());
+            attach_unresolved_import_fixit(&mut diag, unit, &mut result.safe_fixits);
             result.diagnostics.push(diag);
         }
 
@@ -341,6 +342,83 @@ fn unrewrite_imports(
         }
     }
     out
+}
+
+/// If `spec` ends in `.sol` or `.fsol`, returns it with the other dialect
+/// extension. `.fsol` is checked first so it is not treated as `.sol`.
+fn swapped_dialect_spec(spec: &str) -> Option<String> {
+    if let Some(stem) = spec.strip_suffix(".fsol") {
+        Some(format!("{stem}.sol"))
+    } else {
+        spec.strip_suffix(".sol").map(|stem| format!("{stem}.fsol"))
+    }
+}
+
+/// Reads the import specifier out of an FHE1003 diagnostic: prefer the span
+/// text (quotes stripped), then the binder message which quotes the specifier.
+fn specifier_from_fhe1003(diag: &Diagnostic, content: &str) -> Option<String> {
+    if let Some(snippet) = content.get(diag.span.start_byte..diag.span.end_byte) {
+        let trimmed = snippet.trim();
+        let inner = trimmed
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .or_else(|| {
+                trimmed
+                    .strip_prefix('\'')
+                    .and_then(|s| s.strip_suffix('\''))
+            })
+            .unwrap_or(trimmed);
+        if inner.starts_with('.') {
+            return Some(inner.to_string());
+        }
+    }
+    let rest = diag
+        .message
+        .strip_prefix("cannot resolve relative import `")?;
+    let spec = rest.split_once('`')?.0;
+    Some(spec.to_string())
+}
+
+/// When a relative import fails to resolve and swapping `.sol` ↔ `.fsol`
+/// names a file the unit actually discovered, attach a `safe: true` fix-it.
+fn attach_unresolved_import_fixit(
+    diag: &mut Diagnostic,
+    unit: &LoadedUnit,
+    safe_fixits: &mut Vec<(String, ByteRange, String)>,
+) {
+    if diag.code != "FHE1003" {
+        return;
+    }
+    let Some(file) = unit.files.iter().find(|f| f.rel_path == diag.span.file) else {
+        return;
+    };
+    let Some(spec) = specifier_from_fhe1003(diag, &file.content) else {
+        return;
+    };
+    let Some(swapped) = swapped_dialect_spec(&spec) else {
+        return;
+    };
+    let resolved = resolve_relative(&diag.span.file, &swapped);
+    if !unit.files.iter().any(|f| f.rel_path == resolved) {
+        return;
+    }
+    let Some(snippet) = file.content.get(diag.span.start_byte..diag.span.end_byte) else {
+        return;
+    };
+    if !snippet.contains(&spec) {
+        return;
+    }
+    let replacement = snippet.replacen(&spec, &swapped, 1);
+    safe_fixits.push((
+        diag.span.file.clone(),
+        ByteRange::new(diag.span.start_byte, diag.span.end_byte),
+        replacement.clone(),
+    ));
+    diag.fixits.push(FixIt {
+        span: diag.span.clone(),
+        replacement,
+        safe: true,
+    });
 }
 
 /// Resolves a possibly-relative import specifier against the importer's
@@ -566,6 +644,21 @@ mod tests {
         assert_eq!(
             resolve_relative("a/B.fsol", "@scope/pkg/C.sol"),
             "@scope/pkg/C.sol"
+        );
+    }
+
+    #[test]
+    fn swapped_dialect_spec_does_not_treat_fsol_as_sol() {
+        assert_eq!(swapped_dialect_spec("./A.sol").as_deref(), Some("./A.fsol"));
+        assert_eq!(swapped_dialect_spec("./A.fsol").as_deref(), Some("./A.sol"));
+        assert_eq!(
+            swapped_dialect_spec("../lib/X.sol").as_deref(),
+            Some("../lib/X.fsol")
+        );
+        assert_eq!(swapped_dialect_spec("./A.txt"), None);
+        assert_eq!(
+            swapped_dialect_spec("@p/q/A.sol").as_deref(),
+            Some("@p/q/A.fsol")
         );
     }
 

--- a/crates/fhec-cli/tests/cli.rs
+++ b/crates/fhec-cli/tests/cli.rs
@@ -30,11 +30,145 @@ fn init_then_check_succeeds() {
     let out = fhec(tmp.path(), &["check"]);
     assert_eq!(out.status.code(), Some(0), "check: {}", stderr(&out));
     assert!(stdout(&out).is_empty());
+    let err = stderr(&out);
+    assert!(
+        err.contains("file(s) checked clean"),
+        "expected check summary on stderr: {err}"
+    );
+    assert!(err.contains("rewrite site(s)"), "stderr: {err}");
+    assert!(err.contains("config hash"), "stderr: {err}");
+
+    // `--json` keeps the spec §10.2 stream silent on a clean project.
+    let out = fhec(tmp.path(), &["check", "--json"]);
+    assert_eq!(out.status.code(), Some(0), "check --json: {}", stderr(&out));
+    assert!(stdout(&out).is_empty(), "stdout: {}", stdout(&out));
+    assert!(
+        !stderr(&out).contains("checked clean"),
+        "summary must not leak onto --json stderr: {}",
+        stderr(&out)
+    );
 
     // init refuses to overwrite.
     let out = fhec(tmp.path(), &["init"]);
     assert_eq!(out.status.code(), Some(2));
     assert!(stderr(&out).contains("refusing to overwrite"));
+}
+
+#[test]
+fn check_warns_when_include_matches_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(fhec(tmp.path(), &["init"]).status.code(), Some(0));
+    std::fs::create_dir_all(tmp.path().join("empty")).unwrap();
+    std::fs::write(tmp.path().join("fhec.toml"), "[project]\nsrc = \"empty\"\n").unwrap();
+
+    let out = fhec(tmp.path(), &["check"]);
+    assert_eq!(out.status.code(), Some(0), "check: {}", stderr(&out));
+    let err = stderr(&out);
+    assert!(err.contains("FHE1007"), "stderr: {err}");
+    assert!(err.contains("0 file(s) checked clean"), "stderr: {err}");
+
+    let out = fhec(tmp.path(), &["check", "--json"]);
+    assert_eq!(out.status.code(), Some(0), "check --json: {}", stderr(&out));
+    assert!(
+        !stderr(&out).contains("checked clean"),
+        "summary must not leak onto --json stderr: {}",
+        stderr(&out)
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&stdout(&out)).expect("valid JSON array");
+    let arr = parsed.as_array().expect("array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["code"], "FHE1007");
+    assert_eq!(arr[0]["severity"], "warning");
+}
+
+#[test]
+fn unresolved_relative_import_gets_a_safe_extension_fixit() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("fhec.toml"), "").unwrap();
+    std::fs::create_dir_all(tmp.path().join("contracts")).unwrap();
+    std::fs::write(
+        tmp.path().join("contracts/A.fsol"),
+        "pragma solidity ^0.8.25;\ncontract A {}\n",
+    )
+    .unwrap();
+    let b_path = tmp.path().join("contracts/B.fsol");
+    std::fs::write(
+        &b_path,
+        "pragma solidity ^0.8.25;\nimport \"./A.sol\";\ncontract B {}\n",
+    )
+    .unwrap();
+
+    let out = fhec(tmp.path(), &["check", "--json"]);
+    assert_eq!(out.status.code(), Some(1), "check: {}", stderr(&out));
+    let parsed: serde_json::Value = serde_json::from_str(&stdout(&out)).expect("valid JSON array");
+    let arr = parsed.as_array().expect("array");
+    let fhe1003 = arr
+        .iter()
+        .find(|d| d["code"] == "FHE1003")
+        .unwrap_or_else(|| panic!("no FHE1003 in {arr:?}"));
+    let fixits = fhe1003["fixits"].as_array().expect("fixits array");
+    assert_eq!(fixits.len(), 1, "diag: {fhe1003}");
+    assert_eq!(fixits[0]["safe"], true);
+    let replacement = fixits[0]["replacement"].as_str().expect("replacement");
+    assert!(
+        replacement.contains("A.fsol"),
+        "replacement should swap to .fsol: {replacement}"
+    );
+
+    let out = fhec(tmp.path(), &["check", "--fix"]);
+    assert_eq!(out.status.code(), Some(0), "fix: {}", stderr(&out));
+    let fixed = std::fs::read_to_string(&b_path).unwrap();
+    assert!(
+        fixed.contains("import \"./A.fsol\""),
+        "fix-it not applied:\n{fixed}"
+    );
+    assert!(
+        !fixed.contains("import \"./A.sol\""),
+        "old specifier remains:\n{fixed}"
+    );
+}
+
+#[test]
+fn extension_fixit_is_absent_when_swapped_file_was_not_discovered() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("fhec.toml"),
+        "[project]\nexclude = [\"Hidden.fsol\"]\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("contracts")).unwrap();
+    std::fs::write(
+        tmp.path().join("contracts/Hidden.fsol"),
+        "pragma solidity ^0.8.25;\ncontract Hidden {}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("contracts/User.fsol"),
+        "pragma solidity ^0.8.25;\nimport \"./Hidden.sol\";\ncontract User {}\n",
+    )
+    .unwrap();
+
+    let out = fhec(tmp.path(), &["check", "--json"]);
+    assert_eq!(out.status.code(), Some(1), "check: {}", stderr(&out));
+    let parsed: serde_json::Value = serde_json::from_str(&stdout(&out)).expect("valid JSON array");
+    let arr = parsed.as_array().expect("array");
+    let fhe1003 = arr
+        .iter()
+        .find(|d| d["code"] == "FHE1003")
+        .unwrap_or_else(|| panic!("no FHE1003 in {arr:?}"));
+    let fixits = fhe1003.get("fixits").and_then(|v| v.as_array());
+    assert!(
+        fixits.is_none() || fixits.unwrap().is_empty(),
+        "must not attach a safe fix-it for an undiscovered file: {fhe1003}"
+    );
+
+    let out = fhec(tmp.path(), &["check", "--fix"]);
+    assert_eq!(out.status.code(), Some(1), "fix: {}", stderr(&out));
+    assert!(
+        stderr(&out).contains("no safe fix-its to apply"),
+        "stderr: {}",
+        stderr(&out)
+    );
 }
 
 #[test]
@@ -100,6 +234,11 @@ fn explain_known_and_unknown() {
     let text = stdout(&out);
     assert!(text.contains("possibly-uninitialized-encrypted"), "{text}");
     assert!(text.contains("§6"), "{text}");
+
+    let out = fhec(tmp.path(), &["explain", "FHE1007"]);
+    assert_eq!(out.status.code(), Some(0));
+    let text = stdout(&out);
+    assert!(text.contains("no-files-matched"), "{text}");
 
     let out = fhec(tmp.path(), &["explain", "FHE0000"]);
     assert_eq!(out.status.code(), Some(2));
@@ -183,6 +322,22 @@ fn config_missing_reports_draft_code() {
     }
     assert_eq!(out.status.code(), Some(1));
     assert!(stderr(&out).contains("FHE1004"), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn help_documents_all_solc_warnings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = fhec(tmp.path(), &["build", "--help"]);
+    assert_eq!(out.status.code(), Some(0), "help: {}", stderr(&out));
+    let text = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(
+        text.contains("--all-solc-warnings"),
+        "expected flag in CLI help: {text}"
+    );
+    assert!(
+        text.contains("project.src"),
+        "expected the flag to mention project.src: {text}"
+    );
 }
 
 #[test]

--- a/crates/fhec-cli/tests/e2e.rs
+++ b/crates/fhec-cli/tests/e2e.rs
@@ -309,3 +309,126 @@ fn missing_node_modules_gives_install_advice() {
     assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
     assert!(root.join("generated/Counter.sol").is_file());
 }
+
+#[test]
+fn third_party_solc_warnings_are_suppressed_by_default() {
+    if !have_solc() {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join("fhec.toml"), "[project]\nsrc = \"contracts\"\n").unwrap();
+    std::fs::create_dir_all(root.join("contracts")).unwrap();
+    std::fs::create_dir_all(root.join("node_modules/noisy")).unwrap();
+    std::fs::write(
+        root.join("node_modules/noisy/Lib.sol"),
+        "\
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+contract Lib {
+    function f() public pure returns (uint) {
+        return 1;
+        uint x = 2;
+    }
+}
+",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("contracts/User.sol"),
+        "\
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+import \"noisy/Lib.sol\";
+contract User is Lib {
+    function g() public pure returns (uint) {
+        return 1;
+        uint y = 2;
+    }
+}
+",
+    )
+    .unwrap();
+
+    let out = fhec(root, &["build", "--json"]);
+    assert_eq!(out.status.code(), Some(0), "build: {}", stderr(&out));
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout(&out)).unwrap_or_else(|_| serde_json::json!([]));
+    let arr = parsed.as_array().cloned().unwrap_or_default();
+    let warnings: Vec<_> = arr
+        .iter()
+        .filter(|d| d["code"] == "FHE6000" && d["severity"] == "warning")
+        .collect();
+    assert!(
+        warnings.iter().any(|d| d["span"]["file"] == "User.sol"),
+        "expected an in-src warning: {arr:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .all(|d| d["span"]["file"] != "noisy/Lib.sol"),
+        "third-party warning leaked: {arr:?}"
+    );
+
+    let out = fhec(root, &["build", "--json", "--all-solc-warnings"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "build --all-solc-warnings: {}",
+        stderr(&out)
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout(&out)).unwrap_or_else(|_| serde_json::json!([]));
+    let arr = parsed.as_array().cloned().unwrap_or_default();
+    assert!(
+        arr.iter()
+            .any(|d| d["code"] == "FHE6000" && d["span"]["file"] == "noisy/Lib.sol"),
+        "flag must restore the third-party warning: {arr:?}"
+    );
+}
+
+#[test]
+fn third_party_solc_errors_are_always_forwarded() {
+    if !have_solc() {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join("fhec.toml"), "[project]\nsrc = \"contracts\"\n").unwrap();
+    std::fs::create_dir_all(root.join("contracts")).unwrap();
+    std::fs::create_dir_all(root.join("node_modules/noisy")).unwrap();
+    std::fs::write(
+        root.join("node_modules/noisy/Lib.sol"),
+        "\
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+contract Lib {
+    function f() public pure {
+        missingFn();
+    }
+}
+",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("contracts/User.sol"),
+        "\
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+import \"noisy/Lib.sol\";
+contract User is Lib {}
+",
+    )
+    .unwrap();
+
+    let out = fhec(root, &["build", "--json"]);
+    assert_eq!(out.status.code(), Some(1), "build: {}", stderr(&out));
+    let parsed: serde_json::Value = serde_json::from_str(&stdout(&out)).expect("json diagnostics");
+    let arr = parsed.as_array().unwrap();
+    assert!(
+        arr.iter().any(|d| d["code"] == "FHE6000"
+            && d["severity"] == "error"
+            && d["span"]["file"] == "noisy/Lib.sol"),
+        "expected a forwarded third-party error: {arr:?}"
+    );
+}

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -104,10 +104,11 @@ contract EncryptedCounter {
 1. Dialect source files use the extension `.fsol`. Plain `.sol` files in the same project MUST pass through unmodified except §2.6.
 2. A `.fsol` file MUST carry a `pragma solidity` constraint whose satisfiable range lies within `>=0.8.25 <0.9.0`. Constraints outside this range are FHE1001 errors, enforced by the load stage; a pragma the load stage cannot parse defers to solc rather than erroring. (The CoFHE interface file itself requires `>=0.8.25`; CoFHE deployments require the `cancun` EVM target.)
 3. Except for the extensions in §2.3, §2.7, and §2.8, the grammar of `.fsol` is exactly the grammar of Solidity in the supported pragma range. Every valid Solidity file in that range is a valid `.fsol` file.
+4. When `project.include` matches no `.fsol` / `.sol` files under `project.src`, the load stage MUST emit FHE1007 (warning). An empty match is almost always a misconfigured `src` or include glob, not an empty project.
 
 ### §2.2 Parse errors
 
-Input that does not parse under the dialect grammar is rejected with FHE1002. Unresolvable imports are FHE1003.
+Input that does not parse under the dialect grammar is rejected with FHE1002. Unresolvable imports are FHE1003. When a relative specifier fails to resolve and replacing `.sol` with `.fsol` (or the reverse) names a file the compilation unit actually discovered, the diagnostic SHOULD carry a `safe: true` fix-it that rewrites the specifier.
 
 ### §2.3 The `in` parameter sugar
 
@@ -600,6 +601,7 @@ Assigned in this version:
 | FHE1004 | error | config-not-found (no `fhec.toml` for a command that requires one) |
 | FHE1005 | error | config-invalid (`fhec.toml` parse or validation failure) |
 | FHE1006 | error | frozen-drift (`--frozen`: regeneration differs from the committed output tree) |
+| FHE1007 | warning | no-files-matched (`project.include` matched no `.fsol` / `.sol` files under `project.src`) |
 | FHE1010 | error | in-sugar-non-encrypted-type |
 | FHE1011 | error | in-sugar-name-collision (§2.3) |
 | FHE1012 | error | in-sugar-bad-position (§2.3) |
@@ -657,6 +659,8 @@ Assigned in this version:
 | FHE9003 | error | fragment-reparse-failed (§2.5) |
 
 Every diagnostic MUST carry: code, severity, original-source span, message. It SHOULD carry fix-its and a documentation link. Fix-its marked `safe: true` MAY be auto-applied by `--fix`.
+
+Non-error FHE6000 diagnostics whose span is not a discovered file under `project.src` SHOULD be suppressed by default (third-party library warnings are not actionable). Error-severity FHE6000 diagnostics MUST always be forwarded. A CLI that suppresses those warnings MUST provide a flag (`--all-solc-warnings`) that restores them.
 
 ---
 
@@ -722,3 +726,5 @@ A case passes when (a) produced diagnostics equal the expected set (order-insens
 - **0.5.0 (2026-08-27)** — third grammar extension: §2.8 adds the shared boundary. `in shared eT name` lowers a parameter to the profile's `sharedT` wire type and receives it at the materialization point, with no input proof and no batching; `returns (shared(msg.sender) eT)` makes the ABI result `sharedT` and wraps every returned expression in one `share` call, in place, so single evaluation and nested operator lowering both hold by construction. A shared return replaces the §8.3 R3 grant and never costs any other ACL grant. MVP limits: `in shared` on `external` functions only, no data location on either marker, no mixing of shared and external inputs in one parameter list, one unnamed shared return per function, recipient exactly `msg.sender`, explicit valued `return` inside a braced block, no assignment in the returned expression, and no rewrite site in a returned expression whose statement an R2 grant already claims. A call to a shared-return function types as `Unknown`. New codes FHE1015 (bad position or shape), FHE1016 (`<name>_shared` collision), FHE2012 (returned expression is not the declared encrypted type); a profile without a shared boundary for a type reuses FHE5001.
 - **0.4.0 (2026-08-27)** — §2.3 adds the explicit proof binder `in(proof) eT name`: the input verifies against an author-declared `bytes memory|calldata` parameter of the same list, which keeps its position, name, and data location, and nothing is appended to the parameter list, so an ERC-7984 `…AndCall` order (proof before `data`) is expressible. The implicit `in eT name` form and its trailing `bytes memory inputProof` are unchanged. New codes FHE1013 (binder does not name a same-list `bytes` parameter) and FHE1014 (one parameter list mixes the two forms or binds two different proofs).
 - **0.6.0 (2026-08-28)** — §2.9 adds explicit cast sugar: `eT(x)` is sugar for `FHE.as<T>(x)`, rewriting only the callee identifier and leaving the argument byte-identical, so the argument gets exactly the type-checking an author-written `FHE.as<T>(x)` call already receives. This is the first grammar-adjacent extension that adds zero new parser grammar: unlike §2.3, §2.7, and §2.8, it reuses the existing call-expression grammar and resolves purely through name resolution. New code FHE1018 (a call with an argument count other than one).
+- **0.6.1 (2026-08-28)** — FHE1007: the load stage warns when `project.include` matches no source files under `project.src`. Non-error FHE6000 diagnostics from files outside `project.src` are suppressed by default; `--all-solc-warnings` restores them. Errors from any file are still forwarded.
+- **0.6.2 (2026-08-28)** — FHE1003 carries a `safe: true` fix-it when swapping the dialect extension of a relative import names a discovered unit file.


### PR DESCRIPTION
Stacked on the checker PR. Three adoption defects from the port.

**`fhec check` succeeded in silence.** A clean run printed nothing and exited 0, which is indistinguishable from "found nothing to do" — and a wrong `project.src` also printed nothing and exited 0. The former `--verbose` summary is now the default on stderr, and stays silent under `--json`. A `project.include` that matches no files emits the new warning **FHE1007** instead of exiting 0 quietly.

**Third-party solc warnings drowned the real ones.** A clean build of a project using OpenZeppelin emitted five warnings, four from `node_modules`. Non-error FHE6000 from outside `project.src` is now suppressed; `--all-solc-warnings` restores it. Errors from any file always come through.

**Renaming `.sol` to `.fsol` broke every relative import with no way forward.** The ported repo got 76 FHE1003 errors at once and zero fix-its. When a relative specifier fails to resolve and swapping the extension names a file the unit actually discovered, the diagnostic now carries a `safe: true` fix-it, so `fhec check --fix` makes the rename a two-command operation.

Closes #53
Closes #58
Closes #59