### PR TITLE
fix: keep interface ABI names, and prepare the packages for npm

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,52 @@
+# Releasing npm packages
+
+Do not publish until platform binaries exist and an npm account is ready.
+This file is the order of operations. It does not configure CI credentials.
+
+Keep package versions in lockstep (`0.1.0` today):
+
+| Package | Directory | Depends on |
+|---|---|---|
+| `@fhec/cli-<platform>` | `packages/fhec-darwin-arm64` (and later platform dirs) | nothing |
+| `fhec` | `packages/fhec` | optional `@fhec/cli-*` |
+| `@fhec/hardhat-plugin` | `packages/hardhat-plugin` | `fhec` |
+
+pnpm rewrites `workspace:^x.y.z` in `package.json` to `^x.y.z` on publish.
+
+## Preconditions
+
+1. Bump `version` in each package you will publish. Keep the numbers equal.
+2. Run `pnpm install` so `pnpm-lock.yaml` matches.
+3. Run `pnpm -r run --if-present build`.
+4. Run `pnpm --filter @fhec/hardhat-plugin test`.
+5. Stage a native binary into each `@fhec/cli-*` package at `bin/fhec`.
+   `pnpm --filter fhec run build:native` only stages **darwin-arm64** on that
+   host.
+
+Platform packages stay `"private": true` until a binary is in `bin/`. Drop
+that flag on a platform package only when you are ready to publish it.
+
+## Publish order
+
+From the repository root, logged in to npm (`npm whoami`):
+
+```sh
+# 1. Every platform package that has a binary (skip while private).
+pnpm --filter @fhec/cli-darwin-arm64 publish --access public
+
+# 2. The JS wrapper. Optional platform deps must already be on the registry,
+#    or a published `fhec` install has no native binary.
+pnpm --filter fhec publish --access public
+
+# 3. The Hardhat plugin.
+pnpm --filter @fhec/hardhat-plugin publish --access public
+```
+
+Do not add npm tokens to CI in this change.
+
+## Until the first publish
+
+Consumers cannot `pnpm add -D @fhec/hardhat-plugin` from the registry. Use
+the `file:` override plus `FHEC_BINARY_PATH` in
+[`packages/hardhat-plugin/README.md`](packages/hardhat-plugin/README.md)
+(Local checkout).

--- a/crates/fhec-check/src/shared.rs
+++ b/crates/fhec-check/src/shared.rs
@@ -257,8 +257,10 @@ fn scan_params<'ast>(
             refused = true;
             continue;
         }
+        // A bodiless declaration generates no local and keeps the author's
+        // parameter name, so no name is introduced to collide.
         let generated = format!("{}{WIRE_SUFFIX}", name.as_str());
-        if ident_occurs(f.ast, &generated) {
+        if f.ast.body.is_some() && ident_occurs(f.ast, &generated) {
             refused = true;
             out.diagnostics.push(
                 Diagnostic::error(

--- a/crates/fhec-check/src/sugar.rs
+++ b/crates/fhec-check/src/sugar.rs
@@ -92,8 +92,10 @@ pub(crate) fn scan<'ast>(
                 );
                 continue;
             };
+            // A bodiless declaration generates no local and keeps the
+            // author's parameter name, so no name is introduced to collide.
             let generated = format!("{}_input", name.as_str());
-            if ident_occurs(f.ast, &generated) {
+            if f.ast.body.is_some() && ident_occurs(f.ast, &generated) {
                 out.diagnostics.push(
                     Diagnostic::error(
                         codes::IN_SUGAR_NAME_COLLISION,

--- a/crates/fhec-lower/src/pass_ops.rs
+++ b/crates/fhec-lower/src/pass_ops.rs
@@ -304,12 +304,21 @@ fn expand_function_sugar(
     }
     let proof = first.proof.as_deref().unwrap_or(INPUT_PROOF);
 
-    // 1. Each `in eT name` parameter becomes `externalET name_input`.
+    // 1. Each `in eT name` parameter becomes `externalET name_input`. A
+    //    bodiless declaration generates no local, so nothing needs the
+    //    author's name and the parameter keeps it: that name is ABI-visible
+    //    and, on a published interface, is what integrators and
+    //    named-argument call sites bind to (spec §2.3).
     for site in sites {
         let external_ty = ctx.profile.external_input_type(site.ty);
+        let wire_name = if first.has_body {
+            format!("{}_input", site.name)
+        } else {
+            site.name.clone()
+        };
         plan.push(Patch::replace(
             ctx.range(site.param_span),
-            format!("{external_ty} {}_input", site.name),
+            format!("{external_ty} {wire_name}"),
             Provenance::new("§2.3 in-sugar-param", ctx.range(site.param_span)),
         ));
     }
@@ -496,7 +505,15 @@ fn expand_shared_inputs(ctx: &Ctx<'_, '_>, file_idx: usize, plan: &mut FilePlan)
                 .profile
                 .shared_wire_type(site.ty)
                 .map_err(|e| internal(site.param_span, e))?;
-            let wire_name = format!("{}{WIRE_SUFFIX}", site.name);
+            // A bodiless declaration generates no local, so nothing needs
+            // the author's name and the parameter keeps it. That name is
+            // ABI-visible and, on a published interface, is what integrators
+            // and named-argument call sites bind to (spec §2.8).
+            let wire_name = if first.has_body {
+                format!("{}{WIRE_SUFFIX}", site.name)
+            } else {
+                site.name.clone()
+            };
             plan.push(Patch::replace(
                 ctx.range(site.param_span),
                 format!("{wire} {wire_name}"),

--- a/crates/fhec-lower/tests/golden.rs
+++ b/crates/fhec-lower/tests/golden.rs
@@ -774,8 +774,28 @@ fn a_bodiless_shared_declaration_rewrites_its_signature_only() {
          import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
          \n\
          interface I {\n\
-         \x20   function set(sharedEuint32 amount_shared) external;\n\
+         \x20   function set(sharedEuint32 amount) external;\n\
          \x20   function take() external returns (sharedEuint64);\n\
+         }\n",
+    );
+}
+
+#[test]
+fn a_bodiless_declaration_keeps_the_author_parameter_name() {
+    // Spec §2.3 / §2.8: no local is generated, so the ABI-visible parameter
+    // name must not change on a published interface.
+    golden(
+        "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         \n\
+         interface I {\n\
+         \x20   function deposit(in euint32 amount) external;\n\
+         }\n",
+        "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         \n\
+         interface I {\n\
+         \x20   function deposit(externalEuint32 amount, bytes memory inputProof) external;\n\
          }\n",
     );
 }

--- a/fixtures/sugar/proof-binder-bodiless/expected.sol
+++ b/fixtures/sugar/proof-binder-bodiless/expected.sol
@@ -7,12 +7,12 @@ import "@fhenixprotocol/cofhe-contracts/FHE.sol";
 // The bound proof keeps its position, name, and data location, and nothing is
 // appended to the parameter list.
 interface ISugarProofBinderBodiless {
-    function deposit(externalEuint32 amount_input, bytes calldata inputProof) external;
+    function deposit(externalEuint32 amount, bytes calldata inputProof) external;
 }
 
 abstract contract SugarProofBinderBodiless {
     function withdraw(
-        externalEuint64 amount_input,
+        externalEuint64 amount,
         bytes memory sig,
         uint256 tag
     ) public virtual;

--- a/fixtures/sugar/shared-input-bodiless/expected.sol
+++ b/fixtures/sugar/shared-input-bodiless/expected.sol
@@ -6,14 +6,14 @@ import "@fhenixprotocol/cofhe-contracts/FHE.sol";
 // A bodiless declaration rewrites its signature only (§2.8, §2.3 restriction
 // 3): the wire types change, and no receive statement is generated.
 interface ISharedInputBodiless {
-    function deposit(sharedEuint32 amount_shared) external;
+    function deposit(sharedEuint32 amount) external;
 
     function peek() external returns (sharedEuint64);
 }
 
 abstract contract SharedInputBodiless {
     function withdraw(
-        sharedEuint64 amount_shared,
+        sharedEuint64 amount,
         uint256 tag
     ) external virtual returns (sharedEuint64);
 }

--- a/packages/fhec/README.md
+++ b/packages/fhec/README.md
@@ -7,6 +7,11 @@ prebuilt native binary for the current platform/arch and execs it,
 forwarding args and exit code. Resolution lives in `lib/resolve.js` and
 is exported as `fhec/resolve` for the Hardhat plugin and other tooling.
 
+This package is the published JS wrapper (`fhec` on npm). Platform packages
+(`@fhec/cli-<platform>`) are not published yet, so a registry or `file:`
+install still needs `FHEC_BINARY_PATH` (or a local `cargo build`) until
+those packages ship a binary. See [`RELEASING.md`](../../RELEASING.md).
+
 ## Binary resolution order
 
 `fhec/resolve` looks for the native binary in this order, stopping at the

--- a/packages/fhec/package.json
+++ b/packages/fhec/package.json
@@ -1,7 +1,8 @@
 {
   "name": "fhec",
   "version": "0.1.0",
-  "private": true,
+  "description": "npm wrapper for the fhec native binary (platform-package distribution model, a la esbuild/biome)",
+  "license": "MIT",
   "bin": {
     "fhec": "bin/fhec.js"
   },
@@ -11,17 +12,30 @@
       "default": "./lib/resolve.js"
     }
   },
+  "files": [
+    "bin",
+    "lib"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "build:native": "node scripts/build-native.mjs",
     "test": "node --test test/**/*.test.mjs"
   },
   "optionalDependencies": {
-    "@fhec/cli-darwin-arm64": "workspace:*"
+    "@fhec/cli-darwin-arm64": "workspace:^0.1.0"
   },
-  "description": "npm wrapper for the fhec native binary (platform-package distribution model, a la esbuild/biome)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/toml01/fhec.git"
+    "url": "git+https://github.com/toml01/fhec.git",
+    "directory": "packages/fhec"
   },
-  "license": "MIT"
+  "homepage": "https://github.com/toml01/fhec/tree/main/packages/fhec",
+  "bugs": {
+    "url": "https://github.com/toml01/fhec/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/hardhat-plugin/README.md
+++ b/packages/hardhat-plugin/README.md
@@ -75,6 +75,13 @@ is set to `<root>/<out>` so Hardhat compiles the generated tree. On
 If no `fhec.toml` is present at compile time, the plugin throws and tells
 you to run `fhec init` (or set `fhec.enabled: false`).
 
+Hardhat then names artifacts `<out>/Path/File.sol:Name` (default
+`generated/...`), not `contracts/Path/File.sol:Name`. Update
+`getContractFactory`, `deployments.deploy({ contract })`, and
+`verify:verify` to that form. `solidity.overrides` keys that still use the
+source path are rewritten to the `<out>/` form at plugin load, with a
+warning. Test and deploy scripts are not rewritten.
+
 ## Config keys
 
 | Key | Default | Meaning |
@@ -93,3 +100,45 @@ you to run `fhec init` (or set `fhec.enabled: false`).
 - Compatible with `@cofhe/hardhat-plugin`: that plugin appends mock sources
   via `GET_SOURCE_PATHS` and deploys mocks on `test` / `node`. This plugin
   does not touch those tasks.
+
+## Local checkout
+
+These packages are not on the npm registry yet. `pnpm add -D
+@fhec/hardhat-plugin` therefore cannot work from a project outside this
+monorepo: the plugin depends on `fhec` via `workspace:^0.1.0`, and the
+`fhec` wrapper looks for `target/{release,debug}/fhec` relative to the
+cargo checkout.
+
+Until the first publish (see [`RELEASING.md`](../../RELEASING.md)), wire a
+Hardhat 2 project to this checkout as follows.
+
+1. Add the plugin as a `file:` dependency:
+
+   ```sh
+   pnpm add -D file:/abs/path/to/fhec/packages/hardhat-plugin
+   ```
+
+2. pnpm materialises that `file:` dependency in its store, so `fhec@workspace:`
+   is not visible. Override it to the wrapper package:
+
+   ```json
+   {
+     "pnpm": {
+       "overrides": {
+         "fhec": "file:/abs/path/to/fhec/packages/fhec"
+       }
+     }
+   }
+   ```
+
+3. The wrapper's cargo fallback (`../../../target/{release,debug}/fhec`
+   relative to `packages/fhec/lib/resolve.js`) no longer reaches this
+   checkout after the store copy. Point it at a binary you built:
+
+   ```sh
+   cargo build --release -p fhec-cli
+   export FHEC_BINARY_PATH=/abs/path/to/fhec/target/release/fhec
+   ```
+
+Both the override and `FHEC_BINARY_PATH` are required. Neither is enough
+on its own.

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -21,7 +21,7 @@
     "hardhat": "^2.0.0"
   },
   "dependencies": {
-    "fhec": "workspace:*",
+    "fhec": "workspace:^0.1.0",
     "smol-toml": "1.8.0"
   },
   "devDependencies": {
@@ -33,5 +33,12 @@
     "type": "git",
     "url": "git+https://github.com/toml01/fhec.git",
     "directory": "packages/hardhat-plugin"
+  },
+  "homepage": "https://github.com/toml01/fhec/tree/main/packages/hardhat-plugin",
+  "bugs": {
+    "url": "https://github.com/toml01/fhec/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -11,6 +11,10 @@ import { HardhatPluginError } from "hardhat/plugins";
 import type { HardhatConfig, HardhatUserConfig } from "hardhat/types";
 
 import { runFhecBuild } from "./build";
+import {
+  formatOverrideWarning,
+  rewriteSolidityOverrides,
+} from "./overrides";
 import { loadManifest, remapSolcOutput, type RemapContext } from "./remap";
 import { loadFhecToml, resolveTomlPath } from "./toml";
 import {
@@ -27,6 +31,12 @@ export type { FhecConfig, FhecUserConfig, ParsedFhecToml } from "./types";
 export { parseFhecToml, findConfig, resolveTomlPath } from "./toml";
 export { remapRange, matchManifestFile, displaySourcePath, remapSolcOutput } from "./remap";
 export { versionSatisfies, parseSemver } from "./version";
+export {
+  mapSrcKeyToOut,
+  rewriteSolidityOverrides,
+  formatOverrideWarning,
+} from "./overrides";
+export type { OverrideNotice } from "./overrides";
 
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
   const user = userConfig.fhec ?? {};
@@ -58,6 +68,17 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
       resolved.outDir = parsed.out;
       resolved.profileVersion = parsed.version;
       config.paths.sources = path.resolve(config.paths.root, parsed.out);
+      const overrides = config.solidity?.overrides;
+      if (overrides !== undefined) {
+        const notices = rewriteSolidityOverrides(
+          overrides,
+          parsed.src,
+          parsed.out,
+        );
+        if (notices.length > 0) {
+          console.warn(formatOverrideWarning(notices, parsed.src, parsed.out));
+        }
+      }
     }
   }
 

--- a/packages/hardhat-plugin/src/overrides.ts
+++ b/packages/hardhat-plugin/src/overrides.ts
@@ -1,0 +1,127 @@
+import { PLUGIN_NAME } from "./types";
+
+/**
+ * One `solidity.overrides` key that still used the fhec source directory
+ * after the plugin repointed Hardhat `paths.sources` at `out`.
+ */
+export interface OverrideNotice {
+  /** Original key, as written in the Hardhat config. */
+  from: string;
+  /** Key Hardhat will match after `paths.sources` is `out`. */
+  to: string;
+  /**
+   * `rewritten` — the entry was moved to `to`.
+   * `skipped` — `to` already had an entry; the source key is left in place
+   * (Hardhat will ignore it) so the existing destination is not overwritten.
+   */
+  action: "rewritten" | "skipped";
+}
+
+/**
+ * If `key` is a Hardhat source name under `srcDir`, return the same name
+ * under `outDir`. Otherwise return `undefined` (leave the key alone).
+ *
+ * Keys are project-root-relative (Hardhat's `solidity.overrides` form). A
+ * `:Contract` suffix is preserved so a fully-qualified name is rewritten
+ * too, even though overrides usually omit it.
+ */
+export function mapSrcKeyToOut(
+  key: string,
+  srcDir: string,
+  outDir: string,
+): string | undefined {
+  const src = normalizeDir(srcDir);
+  const out = normalizeDir(outDir);
+  if (src === "" || out === "" || src === out) {
+    return undefined;
+  }
+
+  const normalized = normalizePathKey(key);
+  if (normalized === out || normalized.startsWith(`${out}/`)) {
+    return undefined;
+  }
+  if (normalized === src) {
+    return out;
+  }
+  const srcPrefix = `${src}/`;
+  if (normalized.startsWith(srcPrefix)) {
+    return `${out}/${normalized.slice(srcPrefix.length)}`;
+  }
+  return undefined;
+}
+
+/**
+ * Moves `solidity.overrides` entries from `srcDir/...` to `outDir/...` in
+ * place. Returns a notice for every key that matched the source directory.
+ *
+ * Safe: never overwrites an overrides entry that already uses the `out`
+ * path. In that case the source key is left as a no-op and `action` is
+ * `skipped`.
+ */
+export function rewriteSolidityOverrides<T>(
+  overrides: Record<string, T>,
+  srcDir: string,
+  outDir: string,
+): OverrideNotice[] {
+  const notices: OverrideNotice[] = [];
+  for (const key of Object.keys(overrides)) {
+    const to = mapSrcKeyToOut(key, srcDir, outDir);
+    if (to === undefined || to === key) {
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(overrides, to)) {
+      notices.push({ from: key, to, action: "skipped" });
+      continue;
+    }
+    overrides[to] = overrides[key];
+    delete overrides[key];
+    notices.push({ from: key, to, action: "rewritten" });
+  }
+  return notices;
+}
+
+/**
+ * Human-readable warning for rewritten or skipped `solidity.overrides` keys.
+ */
+export function formatOverrideWarning(
+  notices: OverrideNotice[],
+  srcDir: string,
+  outDir: string,
+): string {
+  const src = normalizeDir(srcDir);
+  const out = normalizeDir(outDir);
+  const lines = [
+    `${PLUGIN_NAME}: Hardhat compiles '${out}/', not '${src}/', so artifact fully-qualified names use the '${out}/' prefix.`,
+  ];
+
+  const rewritten = notices.filter((n) => n.action === "rewritten");
+  const skipped = notices.filter((n) => n.action === "skipped");
+
+  if (rewritten.length > 0) {
+    lines.push("Rewrote solidity.overrides keys:");
+    for (const notice of rewritten) {
+      lines.push(`  - "${notice.from}" -> "${notice.to}"`);
+    }
+  }
+  if (skipped.length > 0) {
+    lines.push(
+      "Did not rewrite these solidity.overrides keys (destination already set):",
+    );
+    for (const notice of skipped) {
+      lines.push(`  - "${notice.from}" (would become "${notice.to}")`);
+    }
+  }
+
+  lines.push(
+    `Also update getContractFactory, deployments.deploy({ contract }), and verify:verify to the '${out}/' form.`,
+  );
+  return lines.join("\n");
+}
+
+function normalizePathKey(key: string): string {
+  return key.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function normalizeDir(dir: string): string {
+  return dir.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "");
+}

--- a/packages/hardhat-plugin/test/config.test.js
+++ b/packages/hardhat-plugin/test/config.test.js
@@ -6,8 +6,18 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
+const { spawnSync } = require("node:child_process");
+
 const { parseFhecToml, findConfig } = require("../dist/toml");
 const { versionSatisfies, parseSemver } = require("../dist/version");
+const {
+  mapSrcKeyToOut,
+  rewriteSolidityOverrides,
+  formatOverrideWarning,
+} = require("../dist/overrides");
+
+const pluginRoot = path.resolve(__dirname, "..");
+const pluginEntry = path.join(pluginRoot, "dist", "index.js");
 
 test("empty toml uses defaults", () => {
   assert.deepEqual(parseFhecToml(""), {
@@ -60,5 +70,167 @@ test("findConfig walks upward and returns the nearest fhec.toml", () => {
     assert.equal(findConfig(nested), toml);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("mapSrcKeyToOut rewrites a source-tree override key to out/", () => {
+  assert.equal(
+    mapSrcKeyToOut("contracts/Foo.sol", "contracts", "generated"),
+    "generated/Foo.sol",
+  );
+  assert.equal(
+    mapSrcKeyToOut("contracts/Path/File.sol", "contracts", "generated"),
+    "generated/Path/File.sol",
+  );
+  assert.equal(
+    mapSrcKeyToOut("contracts/Lib.sol:Lib", "contracts", "generated"),
+    "generated/Lib.sol:Lib",
+  );
+  assert.equal(
+    mapSrcKeyToOut("./contracts/Foo.sol", "contracts", "generated"),
+    "generated/Foo.sol",
+  );
+});
+
+test("mapSrcKeyToOut leaves keys that are not under srcDir", () => {
+  assert.equal(
+    mapSrcKeyToOut("generated/Foo.sol", "contracts", "generated"),
+    undefined,
+  );
+  assert.equal(
+    mapSrcKeyToOut("other/Foo.sol", "contracts", "generated"),
+    undefined,
+  );
+  assert.equal(
+    mapSrcKeyToOut("contracts-extra/Foo.sol", "contracts", "generated"),
+    undefined,
+  );
+  assert.equal(
+    mapSrcKeyToOut("contracts/Foo.sol", "contracts", "contracts"),
+    undefined,
+  );
+});
+
+test("rewriteSolidityOverrides moves source keys and does not overwrite out keys", () => {
+  const overrides = {
+    "contracts/Pin.sol": { version: "0.8.26" },
+    "generated/Keep.sol": { version: "0.8.28" },
+    "lib/Other.sol": { version: "0.8.25" },
+  };
+  const notices = rewriteSolidityOverrides(overrides, "contracts", "generated");
+  assert.deepEqual(overrides, {
+    "generated/Pin.sol": { version: "0.8.26" },
+    "generated/Keep.sol": { version: "0.8.28" },
+    "lib/Other.sol": { version: "0.8.25" },
+  });
+  assert.deepEqual(notices, [
+    { from: "contracts/Pin.sol", to: "generated/Pin.sol", action: "rewritten" },
+  ]);
+});
+
+test("rewriteSolidityOverrides skips when the out key already exists", () => {
+  const overrides = {
+    "contracts/Pin.sol": { version: "0.8.26" },
+    "generated/Pin.sol": { version: "0.8.28" },
+  };
+  const notices = rewriteSolidityOverrides(overrides, "contracts", "generated");
+  assert.deepEqual(overrides, {
+    "contracts/Pin.sol": { version: "0.8.26" },
+    "generated/Pin.sol": { version: "0.8.28" },
+  });
+  assert.deepEqual(notices, [
+    { from: "contracts/Pin.sol", to: "generated/Pin.sol", action: "skipped" },
+  ]);
+});
+
+test("formatOverrideWarning names each rewritten key and the generated form", () => {
+  const text = formatOverrideWarning(
+    [{ from: "contracts/Pin.sol", to: "generated/Pin.sol", action: "rewritten" }],
+    "contracts",
+    "generated",
+  );
+  assert.match(text, /@fhec\/hardhat-plugin/);
+  assert.match(text, /"contracts\/Pin\.sol" -> "generated\/Pin\.sol"/);
+  assert.match(text, /getContractFactory/);
+});
+
+function linkLocalHardhat(dir) {
+  const hardhatDir = path.dirname(
+    require.resolve("hardhat/package.json", { paths: [pluginRoot] }),
+  );
+  const nm = path.join(dir, "node_modules");
+  fs.mkdirSync(nm, { recursive: true });
+  fs.symlinkSync(hardhatDir, path.join(nm, "hardhat"));
+}
+
+test("plugin load rewrites solidity.overrides and warns", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-hh-ov-"));
+  try {
+    linkLocalHardhat(dir);
+    fs.writeFileSync(
+      path.join(dir, "fhec.toml"),
+      `[project]\nsrc = "contracts"\nout = "generated"\n`,
+    );
+    fs.writeFileSync(
+      path.join(dir, "hardhat.config.js"),
+      `'use strict';
+require(${JSON.stringify(pluginEntry)});
+module.exports = {
+  solidity: {
+    compilers: [
+      { version: "0.8.28", settings: { evmVersion: "cancun" } },
+    ],
+    overrides: {
+      "contracts/Pin.sol": {
+        version: "0.8.26",
+        settings: { optimizer: { enabled: true, runs: 1 }, evmVersion: "cancun" },
+      },
+    },
+  },
+};
+`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        `const hre = require("hardhat");
+         console.log("FHEC_OVERRIDES_JSON:" + JSON.stringify({
+           overrideKeys: Object.keys(hre.config.solidity.overrides),
+           pinVersion: hre.config.solidity.overrides["generated/Pin.sol"]
+             ? hre.config.solidity.overrides["generated/Pin.sol"].version
+             : null,
+           sources: hre.config.paths.sources,
+         }));`,
+      ],
+      {
+        cwd: dir,
+        encoding: "utf8",
+        env: { ...process.env, HARDHAT_DISABLE_TELEMETRY: "true" },
+      },
+    );
+    assert.equal(
+      result.status,
+      0,
+      `hardhat load failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    const jsonLine = result.stdout
+      .split(/\r?\n/)
+      .find((line) => line.startsWith("FHEC_OVERRIDES_JSON:"));
+    assert.ok(
+      jsonLine,
+      `missing FHEC_OVERRIDES_JSON line\nstdout:\n${result.stdout}`,
+    );
+    const payload = JSON.parse(jsonLine.slice("FHEC_OVERRIDES_JSON:".length));
+    assert.deepEqual(payload.overrideKeys, ["generated/Pin.sol"]);
+    assert.equal(payload.pinVersion, "0.8.26");
+    assert.equal(path.basename(payload.sources), "generated");
+    assert.match(
+      result.stderr,
+      /"contracts\/Pin\.sol" -> "generated\/Pin\.sol"/,
+      `expected rewrite warning\n${result.stderr}`,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
   packages/fhec:
     optionalDependencies:
       '@fhec/cli-darwin-arm64':
-        specifier: workspace:*
+        specifier: workspace:^0.1.0
         version: link:../fhec-darwin-arm64
 
   packages/fhec-darwin-arm64: {}
@@ -76,7 +76,7 @@ importers:
   packages/hardhat-plugin:
     dependencies:
       fhec:
-        specifier: workspace:*
+        specifier: workspace:^0.1.0
         version: link:../fhec
       smol-toml:
         specifier: 1.8.0

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -157,6 +157,8 @@ The bound parameter is an ordinary author-declared parameter everywhere else: it
 
 A modifier invocation is part of the function *header* and is evaluated before the body opens, but `<name>` only exists from the materialization point onwards. A modifier argument that names an `in` / `in(proof)` / `in shared` parameter would therefore reference an identifier the output does not declare there, so the transpiler MUST refuse with FHE1019 rather than emit it.
 
+On a **bodiless** declaration the §2.3 expansion likewise generates no local, so the parameter keeps the author's name and only its type changes; the appended proof parameter is unaffected.
+
 **⚠ Draft decision (generated names):** the raw-input parameter is named `<name>_input`, and, in the implicit form, the appended proof parameter is named `inputProof`. If `<name>_input` is already declared anywhere in the function's scope (parameters, locals, contract members referenced unqualified), the transpiler MUST reject with FHE1011 rather than rename silently; the same applies to `inputProof` in the implicit form. The explicit binder introduces **no** new fixed generated name — it reuses the author's own parameter name verbatim — so `inputProof` is not reserved in a bound function and a parameter of that name is the ordinary case there.
 
 **Restrictions.**
@@ -275,6 +277,8 @@ Several shared inputs of one function receive **independently**, one statement e
 5. **⚠ Draft decision (no mixed inputs):** one parameter list declares either shared inputs or external `in` / `in(proof)` inputs, never both. The two verify under different models — several external inputs form one atomic proof batch — and this version fixes no ordering between that batch and the receives. Splitting the function is the workaround.
 6. On a declaration without a body, only the signature rewrite applies; no receive statement is generated (as §2.3 restriction 3). The visibility rule of restriction 1 still holds, so an interface or abstract declaration carrying `in shared` must be `external`.
 7. The declaration takes no data location. Encrypted types and shared handles are value types, so `memory`, `calldata`, `storage`, and `transient` are all illegal — as they are in plain Solidity on the same type. The transpiler MUST refuse rather than drop the keyword while rewriting the declaration (§1.3).
+
+On a **bodiless** declaration (an interface member or an abstract function) the expansion generates no local, so the parameter keeps the author's name and only its type changes. That name is ABI-visible: on a published interface it is what integrators read and what named-argument call sites bind to, and a signature-only rewrite must not change it.
 
 **⚠ Draft decision (generated name):** the wire parameter is named `<name>_shared`. If that identifier is already used anywhere in the function's scope, the transpiler MUST reject with FHE1016 rather than rename silently.
 


### PR DESCRIPTION
Stacked on the ACL PR.

**The sugar renamed a published interface's ABI parameters.** `in shared euint64 amount` emitted `sharedEuint64 amount_shared`, and that name reached the compiled ABI. On a bodiless declaration the expansion generates no local, so nothing needs the author's name — the parameter now keeps it and only the type changes. A published interface keeps the names integrators read and named-argument call sites bind to.

On a function with a body the rename stays and cannot go: the generated local must carry the name, so the parameter cannot. The FHE1011/FHE1016 collision checks are now gated on the function having a body, since a bodiless declaration introduces no name to collide.

**Packaging.** `packages/fhec` is no longer `private`; both packages carry `files`, `engines`, `repository.directory`, `homepage`, `bugs` and `publishConfig.access`. The `workspace:*` pins became `workspace:^0.1.0`, which pnpm rewrites to a real range on publish while still resolving inside the workspace. `RELEASING.md` records the publish order, and the plugin README documents the local-checkout workaround.

The plugin also rewrites `solidity.overrides` keys that still point at the source path, so a compiler-settings pin keeps working after the plugin repoints `paths.sources`.

Nothing was published and no CI credentials were added. #48 and #54 stay open: the install path is not fixed until the packages are on npm, and fully-qualified names are addressed separately.

Closes #52