### PR TITLE
feat(plugin): resolve a .fsol path in a fully-qualified name

### DIFF
--- a/packages/hardhat-plugin/README.md
+++ b/packages/hardhat-plugin/README.md
@@ -76,11 +76,36 @@ If no `fhec.toml` is present at compile time, the plugin throws and tells
 you to run `fhec init` (or set `fhec.enabled: false`).
 
 Hardhat then names artifacts `<out>/Path/File.sol:Name` (default
-`generated/...`), not `contracts/Path/File.sol:Name`. Update
-`getContractFactory`, `deployments.deploy({ contract })`, and
-`verify:verify` to that form. `solidity.overrides` keys that still use the
-source path are rewritten to the `<out>/` form at plugin load, with a
-warning. Test and deploy scripts are not rewritten.
+`generated/...`), not `contracts/Path/File.sol:Name`. `solidity.overrides`
+keys that still use the source path are rewritten to the `<out>/` form at
+plugin load, with a warning. Test and deploy scripts are not rewritten —
+name the `.fsol` file instead, as below.
+
+## Naming a `.fsol` file directly
+
+You can name the `.fsol` file you actually edit — the one under `src`, not
+`out` — in a fully-qualified name, and it resolves to the generated
+artifact:
+
+```ts
+await ethers.getContractFactory(
+  "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+);
+```
+
+This works for `hre.artifacts.readArtifact` / `readArtifactSync` /
+`artifactExists` / `getBuildInfo` / `getBuildInfoSync` /
+`formArtifactPathFromFullyQualifiedName`. The lookup uses
+`generated/.fhec/manifest.json`, so it only works once you have run
+`hardhat compile` at least once (the manifest is written there); before
+that, or for a path the manifest does not know about, the name you gave is
+passed straight through to Hardhat unchanged — you get Hardhat's normal
+"contract not found" error, not a silent miss.
+
+A plain pass-through `.sol` file (one with no dialect features, copied
+byte-identical into `out`) is not translated by this alias: it already
+keeps its own name, so name it with the `<out>/` prefix directly, as
+before.
 
 ## Config keys
 

--- a/packages/hardhat-plugin/README.md
+++ b/packages/hardhat-plugin/README.md
@@ -108,6 +108,17 @@ byte-identical into `out`) is not translated by this alias: it already
 keeps its own name, so name it with the `<out>/` prefix directly, as
 before.
 
+**`verify:verify` is covered too**, when
+[`@nomicfoundation/hardhat-verify`](https://www.npmjs.com/package/@nomicfoundation/hardhat-verify)
+is installed — both `npx hardhat verify --contract <fqn> ...` and a
+script's own `run("verify:verify", { contract: <fqn>, ... })`. A `.fsol`
+`--contract` argument is translated to the generated `.sol` path before
+Etherscan (or another explorer) sees it, since it must receive the source
+that produced the bytecode. This does not depend on whether
+`hardhat-verify` or `@fhec/hardhat-plugin` is `require`d first in your
+Hardhat config. If `hardhat-verify` is not installed, nothing is
+registered.
+
 ## Config keys
 
 | Key | Default | Meaning |

--- a/packages/hardhat-plugin/README.md
+++ b/packages/hardhat-plugin/README.md
@@ -95,8 +95,9 @@ await ethers.getContractFactory(
 
 This works for `hre.artifacts.readArtifact` / `readArtifactSync` /
 `artifactExists` / `getBuildInfo` / `getBuildInfoSync` /
-`formArtifactPathFromFullyQualifiedName`. The lookup uses
-`generated/.fhec/manifest.json`, so it only works once you have run
+`formArtifactPathFromFullyQualifiedName`, and for `solidity.overrides` keys
+(rewritten in place at config load, with a console warning). The lookup
+uses `generated/.fhec/manifest.json`, so it only works once you have run
 `hardhat compile` at least once (the manifest is written there); before
 that, or for a path the manifest does not know about, the name you gave is
 passed straight through to Hardhat unchanged — you get Hardhat's normal

--- a/packages/hardhat-plugin/src/artifacts.ts
+++ b/packages/hardhat-plugin/src/artifacts.ts
@@ -1,0 +1,73 @@
+import type { Artifacts, HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { translateFsolFqn } from "./fqn";
+import { loadManifest } from "./remap";
+
+/**
+ * `Artifacts` methods whose first argument is a contract name or fully
+ * qualified name, and so are worth resolving through the manifest. This is
+ * the real Hardhat 2.29 method set (checked against the installed
+ * `hardhat/types/artifacts.d.ts`), not the task's suggested names verbatim:
+ * `getArtifactPath`/`getArtifactPathSync` do not exist on `Artifacts` — the
+ * closest public equivalent is `formArtifactPathFromFullyQualifiedName`,
+ * which is covered here, along with `getBuildInfo`/`getBuildInfoSync`
+ * (same shape of argument, same benefit).
+ */
+const TRANSLATED_METHODS: ReadonlySet<string> = new Set([
+  "readArtifact",
+  "readArtifactSync",
+  "artifactExists",
+  "getBuildInfo",
+  "getBuildInfoSync",
+  "formArtifactPathFromFullyQualifiedName",
+]);
+
+/**
+ * Resolves `fqn` against the manifest, per-call (the manifest may not exist
+ * until after `hardhat compile` has run `fhec build`, and can change between
+ * calls in the same process). Falls through to `fqn` unchanged when the
+ * plugin is disabled, no manifest is on disk yet, or `fqn` does not name a
+ * `.fsol` file under `srcDir`.
+ */
+function resolveFqn(hre: HardhatRuntimeEnvironment, fqn: string): string {
+  const fhec = hre.config.fhec;
+  if (!fhec.enabled) {
+    return fqn;
+  }
+  const manifest = loadManifest(hre.config.paths.sources);
+  if (manifest === undefined) {
+    return fqn;
+  }
+  return translateFsolFqn(fqn, fhec.srcDir, fhec.outDir, manifest) ?? fqn;
+}
+
+/**
+ * Wraps `hre.artifacts` so a fully-qualified (or bare) name that still uses
+ * the `.fsol` source path — `contracts/Path/File.fsol:Name` — resolves to
+ * the generated artifact, on {@link TRANSLATED_METHODS}.
+ *
+ * This is a `Proxy` over the original `Artifacts` implementation, not a
+ * plain object copy: Hardhat's own `builtin-tasks/compile.ts` calls
+ * `artifacts.addValidArtifacts(...)`, a method the concrete `Artifacts`
+ * class exposes but the public `Artifacts` *type* does not declare. A
+ * hand-written replacement object — even one that binds and forwards every
+ * documented method — silently drops methods like that one, breaking
+ * `hardhat compile`. The `Proxy` instead forwards every property it does
+ * not explicitly translate straight through to the original instance, with
+ * function properties bound to it so their internal `this` still works.
+ */
+export function wrapArtifacts(hre: HardhatRuntimeEnvironment): Artifacts {
+  const original = hre.artifacts;
+  return new Proxy(original, {
+    get(target, prop, receiver) {
+      if (typeof prop === "string" && TRANSLATED_METHODS.has(prop)) {
+        const fn = Reflect.get(target, prop, receiver);
+        if (typeof fn === "function") {
+          return (name: string, ...rest: unknown[]) => fn.call(target, resolveFqn(hre, name), ...rest);
+        }
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}

--- a/packages/hardhat-plugin/src/fqn.ts
+++ b/packages/hardhat-plugin/src/fqn.ts
@@ -1,0 +1,74 @@
+import type { Manifest } from "./types";
+
+/**
+ * Splits a Hardhat fully-qualified name (`path/File.sol:Contract`) into its
+ * file and contract-name parts. A bare contract name (no `:`) has no file
+ * part. The contract name never contains `:`, so splitting on the *last*
+ * `:` is unambiguous even though POSIX paths could in principle contain one.
+ */
+function splitFqn(fqn: string): { file: string; name: string | undefined } {
+  const idx = fqn.lastIndexOf(":");
+  if (idx === -1) {
+    return { file: fqn, name: undefined };
+  }
+  return { file: fqn.slice(0, idx), name: fqn.slice(idx + 1) };
+}
+
+function normalize(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function normalizeDir(dir: string): string {
+  return normalize(dir).replace(/^\.\/+/, "").replace(/\/+$/, "");
+}
+
+/**
+ * Strips `dir/` (or an exact match on `dir`) from the front of `value`.
+ * Returns `undefined` when `value` is not under `dir`.
+ */
+function stripDir(value: string, dir: string): string | undefined {
+  const normalizedDir = normalizeDir(dir);
+  const normalizedValue = normalize(value);
+  if (normalizedDir.length === 0) {
+    return normalizedValue;
+  }
+  if (normalizedValue === normalizedDir) {
+    return "";
+  }
+  const prefix = `${normalizedDir}/`;
+  if (normalizedValue.startsWith(prefix)) {
+    return normalizedValue.slice(prefix.length);
+  }
+  return undefined;
+}
+
+/**
+ * Translates a Hardhat fully-qualified name (or bare source-relative path)
+ * naming a `.fsol` file under `srcDir` to the same file's manifest `output`
+ * under `outDir`. The `:Contract` suffix, if present, is preserved as-is.
+ *
+ * Returns `undefined` — meaning "leave the input unchanged" — when:
+ * - the FQN has no file part under `srcDir`,
+ * - the file does not end in `.fsol` (a pass-through `.sol` file keeps its
+ *   own name and needs no alias), or
+ * - no manifest entry matches (an unknown FQN passes through unchanged).
+ */
+export function translateFsolFqn(
+  fqn: string,
+  srcDir: string,
+  outDir: string,
+  manifest: Manifest,
+): string | undefined {
+  const { file, name } = splitFqn(fqn);
+  const rel = stripDir(file, srcDir);
+  if (rel === undefined || !rel.endsWith(".fsol")) {
+    return undefined;
+  }
+  const entry = manifest.files.find((candidate) => normalize(candidate.source) === rel);
+  if (entry === undefined) {
+    return undefined;
+  }
+  const out = normalizeDir(outDir);
+  const outPath = out.length > 0 ? `${out}/${entry.output}` : entry.output;
+  return name !== undefined ? `${outPath}:${name}` : outPath;
+}

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -6,10 +6,11 @@ import {
   TASK_COMPILE_SOLIDITY_RUN_SOLC,
   TASK_COMPILE_SOLIDITY_RUN_SOLCJS,
 } from "hardhat/builtin-tasks/task-names";
-import { extendConfig, subtask, task } from "hardhat/config";
+import { extendConfig, extendEnvironment, subtask, task } from "hardhat/config";
 import { HardhatPluginError } from "hardhat/plugins";
 import type { HardhatConfig, HardhatUserConfig } from "hardhat/types";
 
+import { wrapArtifacts } from "./artifacts";
 import { runFhecBuild } from "./build";
 import {
   formatOverrideWarning,
@@ -37,6 +38,8 @@ export {
   formatOverrideWarning,
 } from "./overrides";
 export type { OverrideNotice } from "./overrides";
+export { translateFsolFqn } from "./fqn";
+export { wrapArtifacts } from "./artifacts";
 
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
   const user = userConfig.fhec ?? {};
@@ -83,6 +86,13 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
   }
 
   config.fhec = resolved;
+});
+
+extendEnvironment((hre) => {
+  if (!hre.config.fhec.enabled) {
+    return;
+  }
+  (hre as { artifacts: typeof hre.artifacts }).artifacts = wrapArtifacts(hre);
 });
 
 task(TASK_COMPILE, async (args, hre, runSuper) => {

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -12,10 +12,7 @@ import type { HardhatConfig, HardhatUserConfig } from "hardhat/types";
 
 import { wrapArtifacts } from "./artifacts";
 import { runFhecBuild } from "./build";
-import {
-  formatOverrideWarning,
-  rewriteSolidityOverrides,
-} from "./overrides";
+import { formatOverrideWarning, rewriteSolidityOverrides } from "./overrides";
 import { loadManifest, remapSolcOutput, type RemapContext } from "./remap";
 import { loadFhecToml, resolveTomlPath } from "./toml";
 import {
@@ -33,7 +30,7 @@ export { parseFhecToml, findConfig, resolveTomlPath } from "./toml";
 export { remapRange, matchManifestFile, displaySourcePath, remapSolcOutput } from "./remap";
 export { versionSatisfies, parseSemver } from "./version";
 export {
-  mapSrcKeyToOut,
+  mapOverrideKey,
   rewriteSolidityOverrides,
   formatOverrideWarning,
 } from "./overrides";
@@ -71,16 +68,19 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
       resolved.outDir = parsed.out;
       resolved.profileVersion = parsed.version;
       config.paths.sources = path.resolve(config.paths.root, parsed.out);
-      const overrides = config.solidity?.overrides;
-      if (overrides !== undefined) {
-        const notices = rewriteSolidityOverrides(
-          overrides,
-          parsed.src,
-          parsed.out,
-        );
-        if (notices.length > 0) {
-          console.warn(formatOverrideWarning(notices, parsed.src, parsed.out));
-        }
+
+      // The manifest from a previous `fhec build` may already be on disk;
+      // if not, `.fsol` override keys are left alone (see overrides.ts),
+      // and plain `.sol` keys are still moved to `out/`.
+      const manifest = loadManifest(config.paths.sources);
+      const notices = rewriteSolidityOverrides(
+        config.solidity.overrides,
+        parsed.src,
+        parsed.out,
+        manifest,
+      );
+      if (notices.length > 0) {
+        console.warn(formatOverrideWarning(notices, parsed.src, parsed.out));
       }
     }
   }

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -22,6 +22,7 @@ import {
   PLUGIN_NAME,
   type FhecConfig,
 } from "./types";
+import { installVerifyOverride } from "./verify";
 
 import "./type-extensions";
 
@@ -37,6 +38,7 @@ export {
 export type { OverrideNotice } from "./overrides";
 export { translateFsolFqn } from "./fqn";
 export { wrapArtifacts } from "./artifacts";
+export { installVerifyOverride } from "./verify";
 
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
   const user = userConfig.fhec ?? {};
@@ -93,6 +95,7 @@ extendEnvironment((hre) => {
     return;
   }
   (hre as { artifacts: typeof hre.artifacts }).artifacts = wrapArtifacts(hre);
+  installVerifyOverride(hre);
 });
 
 task(TASK_COMPILE, async (args, hre, runSuper) => {

--- a/packages/hardhat-plugin/src/overrides.ts
+++ b/packages/hardhat-plugin/src/overrides.ts
@@ -1,4 +1,5 @@
 import { PLUGIN_NAME } from "./types";
+import type { Manifest } from "./types";
 
 /**
  * One `solidity.overrides` key that still used the fhec source directory
@@ -17,6 +18,23 @@ export interface OverrideNotice {
   action: "rewritten" | "skipped";
 }
 
+function normalizeDir(dir: string): string {
+  return dir.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/\/+$/, "");
+}
+
+function normalizeKey(key: string): string {
+  return key.replace(/\\/g, "/").replace(/^\.\/+/, "");
+}
+
+/** Splits a `path[:Contract]` override key on its last `:`. */
+function splitContractSuffix(key: string): { path: string; suffix: string } {
+  const idx = key.lastIndexOf(":");
+  if (idx === -1) {
+    return { path: key, suffix: "" };
+  }
+  return { path: key.slice(0, idx), suffix: key.slice(idx) };
+}
+
 /**
  * If `key` is a Hardhat source name under `srcDir`, return the same name
  * under `outDir`. Otherwise return `undefined` (leave the key alone).
@@ -24,11 +42,17 @@ export interface OverrideNotice {
  * Keys are project-root-relative (Hardhat's `solidity.overrides` form). A
  * `:Contract` suffix is preserved so a fully-qualified name is rewritten
  * too, even though overrides usually omit it.
+ *
+ * A plain `.sol` pass-through file keeps its own name — only the directory
+ * prefix changes, and this needs no manifest. A `.fsol` file is renamed by
+ * fhec, so its new name is looked up in `manifest`; without a manifest
+ * entry a `.fsol` key is left alone rather than guessed at.
  */
-export function mapSrcKeyToOut(
+export function mapOverrideKey(
   key: string,
   srcDir: string,
   outDir: string,
+  manifest: Manifest | undefined,
 ): string | undefined {
   const src = normalizeDir(srcDir);
   const out = normalizeDir(outDir);
@@ -36,18 +60,29 @@ export function mapSrcKeyToOut(
     return undefined;
   }
 
-  const normalized = normalizePathKey(key);
-  if (normalized === out || normalized.startsWith(`${out}/`)) {
+  const { path: filePath, suffix } = splitContractSuffix(normalizeKey(key));
+  if (filePath === out || filePath.startsWith(`${out}/`)) {
     return undefined;
   }
-  if (normalized === src) {
-    return out;
+
+  let rel: string | undefined;
+  if (filePath === src) {
+    rel = "";
+  } else if (filePath.startsWith(`${src}/`)) {
+    rel = filePath.slice(src.length + 1);
+  } else {
+    return undefined;
   }
-  const srcPrefix = `${src}/`;
-  if (normalized.startsWith(srcPrefix)) {
-    return `${out}/${normalized.slice(srcPrefix.length)}`;
+
+  if (rel.endsWith(".fsol")) {
+    const entry = manifest?.files.find((candidate) => candidate.source.replace(/\\/g, "/") === rel);
+    if (entry === undefined) {
+      return undefined;
+    }
+    return `${out}/${entry.output}${suffix}`;
   }
-  return undefined;
+
+  return rel.length > 0 ? `${out}/${rel}${suffix}` : `${out}${suffix}`;
 }
 
 /**
@@ -62,10 +97,11 @@ export function rewriteSolidityOverrides<T>(
   overrides: Record<string, T>,
   srcDir: string,
   outDir: string,
+  manifest: Manifest | undefined,
 ): OverrideNotice[] {
   const notices: OverrideNotice[] = [];
   for (const key of Object.keys(overrides)) {
-    const to = mapSrcKeyToOut(key, srcDir, outDir);
+    const to = mapOverrideKey(key, srcDir, outDir, manifest);
     if (to === undefined || to === key) {
       continue;
     }
@@ -113,15 +149,7 @@ export function formatOverrideWarning(
   }
 
   lines.push(
-    `Also update getContractFactory, deployments.deploy({ contract }), and verify:verify to the '${out}/' form.`,
+    `Also update getContractFactory and deployments.deploy({ contract }) to the '${out}/' form, or the '.fsol' form if this version of the plugin supports it.`,
   );
   return lines.join("\n");
-}
-
-function normalizePathKey(key: string): string {
-  return key.replace(/\\/g, "/").replace(/^\.\//, "");
-}
-
-function normalizeDir(dir: string): string {
-  return dir.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "");
 }

--- a/packages/hardhat-plugin/src/verify.ts
+++ b/packages/hardhat-plugin/src/verify.ts
@@ -1,0 +1,87 @@
+import type { HardhatRuntimeEnvironment, RunTaskFunction, TaskArguments, TaskIdentifier } from "hardhat/types";
+
+import { translateFsolFqn } from "./fqn";
+import { loadManifest } from "./remap";
+
+/**
+ * `@nomicfoundation/hardhat-verify`'s subtask name. Kept as a literal
+ * because we cannot depend on that (optional, third-party) package's own
+ * exported constant.
+ */
+const TASK_VERIFY_VERIFY = "verify:verify";
+
+function taskNameOf(identifier: TaskIdentifier): string | undefined {
+  if (typeof identifier === "string") {
+    return identifier;
+  }
+  if (
+    typeof identifier === "object" &&
+    identifier !== null &&
+    typeof identifier.task === "string" &&
+    identifier.scope === undefined
+  ) {
+    return identifier.task;
+  }
+  return undefined;
+}
+
+/**
+ * Translates `args.contract` — a `path:Contract` fully-qualified name — from
+ * the fhec source path to the generated path, when it names a `.fsol` file
+ * the manifest knows about. Etherscan (or another block explorer) must
+ * receive the source that actually produced the bytecode, which is the
+ * generated `.sol`, so this direction is deliberate. Anything we cannot
+ * confidently translate is passed through untouched.
+ */
+function translateVerifyArgs(hre: HardhatRuntimeEnvironment, args: TaskArguments): TaskArguments {
+  if (args === undefined || args === null || typeof args !== "object" || typeof args.contract !== "string") {
+    return args;
+  }
+  const fhec = hre.config.fhec;
+  if (!fhec.enabled) {
+    return args;
+  }
+  const manifest = loadManifest(hre.config.paths.sources);
+  if (manifest === undefined) {
+    return args;
+  }
+  const translated = translateFsolFqn(args.contract, fhec.srcDir, fhec.outDir, manifest);
+  if (translated === undefined) {
+    return args;
+  }
+  return { ...args, contract: translated };
+}
+
+/**
+ * Wraps `hre.run` so a call that targets `verify:verify` — whether from
+ * `npx hardhat verify` (which calls it internally) or a script's own
+ * `hre.run("verify:verify", ...)` — has its `args.contract` translated.
+ *
+ * This wraps `hre.run` itself, not the task definition, so it does not
+ * depend on whether `@fhec/hardhat-plugin` or `@nomicfoundation/hardhat-verify`
+ * is `require`d first in the user's Hardhat config: task registration (and
+ * so require order) only matters for `task()`/`subtask()` calls, and those
+ * are all resolved by the time any `extendEnvironment` callback (this one
+ * included) runs. If the task the third-party plugin defines is absent —
+ * that plugin is not installed, or the user's version does not register it
+ * under this name — nothing is registered: there would be nothing for a
+ * broken override's `runSuper` to call.
+ */
+export function installVerifyOverride(hre: HardhatRuntimeEnvironment): void {
+  if (!hre.config.fhec.enabled) {
+    return;
+  }
+  if (hre.tasks[TASK_VERIFY_VERIFY] === undefined) {
+    return;
+  }
+
+  const original: RunTaskFunction = hre.run;
+  const wrapped: RunTaskFunction = (taskIdentifier, taskArguments, subtaskArguments) => {
+    const args =
+      taskNameOf(taskIdentifier) === TASK_VERIFY_VERIFY
+        ? translateVerifyArgs(hre, taskArguments)
+        : taskArguments;
+    return original(taskIdentifier, args, subtaskArguments);
+  };
+  (hre as { run: RunTaskFunction }).run = wrapped;
+}

--- a/packages/hardhat-plugin/test/artifacts.test.js
+++ b/packages/hardhat-plugin/test/artifacts.test.js
@@ -1,0 +1,156 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { wrapArtifacts } = require("../dist/artifacts");
+
+function writeManifest(sourcesDir, manifest) {
+  const dir = path.join(sourcesDir, ".fhec");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify(manifest));
+}
+
+function sampleManifest() {
+  return {
+    tool: "fhec",
+    version: "0.0.0",
+    files: [
+      {
+        output: "ERC20Confidential/ERC20ConfidentialLib.sol",
+        source: "ERC20Confidential/ERC20ConfidentialLib.fsol",
+        no_op: false,
+        mappings: [],
+      },
+    ],
+  };
+}
+
+function fakeOriginalArtifacts(recorder) {
+  return {
+    readArtifact: async (name) => {
+      recorder.push(["readArtifact", name]);
+      return { contractName: name };
+    },
+    readArtifactSync: (name) => {
+      recorder.push(["readArtifactSync", name]);
+      return { contractName: name };
+    },
+    artifactExists: async (name) => {
+      recorder.push(["artifactExists", name]);
+      return true;
+    },
+    getAllFullyQualifiedNames: async () => ["untouched"],
+    getBuildInfo: async (name) => {
+      recorder.push(["getBuildInfo", name]);
+      return undefined;
+    },
+    getBuildInfoSync: (name) => {
+      recorder.push(["getBuildInfoSync", name]);
+      return undefined;
+    },
+    getArtifactPaths: async () => [],
+    getDebugFilePaths: async () => [],
+    getBuildInfoPaths: async () => [],
+    saveArtifactAndDebugFile: async () => {},
+    saveBuildInfo: async () => "id",
+    formArtifactPathFromFullyQualifiedName: (name) => {
+      recorder.push(["formArtifactPathFromFullyQualifiedName", name]);
+      return `/artifacts/${name}`;
+    },
+  };
+}
+
+function makeHre(sourcesDir, recorder, enabled = true) {
+  return {
+    config: {
+      fhec: { enabled, srcDir: "contracts", outDir: "generated" },
+      paths: { sources: sourcesDir },
+    },
+    artifacts: fakeOriginalArtifacts(recorder),
+  };
+}
+
+test("readArtifact resolves a .fsol FQN to the manifest output before delegating", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-artifacts-"));
+  try {
+    writeManifest(dir, sampleManifest());
+    const recorder = [];
+    const hre = makeHre(dir, recorder);
+    const wrapped = wrapArtifacts(hre);
+    await wrapped.readArtifact("contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib");
+    assert.deepEqual(recorder, [
+      ["readArtifact", "generated/ERC20Confidential/ERC20ConfidentialLib.sol:ERC20ConfidentialLib"],
+    ]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an unknown FQN passes through unchanged", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-artifacts-"));
+  try {
+    writeManifest(dir, sampleManifest());
+    const recorder = [];
+    const hre = makeHre(dir, recorder);
+    const wrapped = wrapArtifacts(hre);
+    await wrapped.readArtifact("contracts/DoesNotExist.fsol:Name");
+    assert.deepEqual(recorder, [["readArtifact", "contracts/DoesNotExist.fsol:Name"]]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("with no manifest present, names pass through unchanged", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-artifacts-"));
+  try {
+    const recorder = [];
+    const hre = makeHre(dir, recorder);
+    const wrapped = wrapArtifacts(hre);
+    wrapped.readArtifactSync("contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib");
+    assert.deepEqual(recorder, [
+      [
+        "readArtifactSync",
+        "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+      ],
+    ]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("formArtifactPathFromFullyQualifiedName translates too", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-artifacts-"));
+  try {
+    writeManifest(dir, sampleManifest());
+    const recorder = [];
+    const hre = makeHre(dir, recorder);
+    const wrapped = wrapArtifacts(hre);
+    wrapped.formArtifactPathFromFullyQualifiedName(
+      "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+    );
+    assert.deepEqual(recorder, [
+      [
+        "formArtifactPathFromFullyQualifiedName",
+        "generated/ERC20Confidential/ERC20ConfidentialLib.sol:ERC20ConfidentialLib",
+      ],
+    ]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("methods with no name argument still delegate", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-artifacts-"));
+  try {
+    const recorder = [];
+    const hre = makeHre(dir, recorder);
+    const wrapped = wrapArtifacts(hre);
+    assert.deepEqual(await wrapped.getAllFullyQualifiedNames(), ["untouched"]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/hardhat-plugin/test/compile.test.js
+++ b/packages/hardhat-plugin/test/compile.test.js
@@ -96,6 +96,55 @@ function artifactExists(dir, contractFile, contractName) {
   return candidates.some((p) => fs.existsSync(p));
 }
 
+function writeReadArtifactTaskProject(dir) {
+  fs.mkdirSync(path.join(dir, "contracts", "Nested"), { recursive: true });
+  linkLocalHardhat(dir);
+  fs.writeFileSync(
+    path.join(dir, "hardhat.config.js"),
+    `'use strict';
+const { task } = require("hardhat/config");
+require(${JSON.stringify(pluginEntry)});
+task("fhec-test-read-artifact", async (args, hre) => {
+  const artifact = await hre.artifacts.readArtifact("contracts/Nested/D.fsol:D");
+  console.log(
+    "FHEC_TEST_RESULT:" +
+      JSON.stringify({ contractName: artifact.contractName, sourceName: artifact.sourceName }),
+  );
+});
+module.exports = {
+  solidity: {
+    version: "0.8.28",
+    settings: { evmVersion: "cancun" },
+  },
+};
+`,
+  );
+  fs.writeFileSync(
+    path.join(dir, "fhec.toml"),
+    `[project]
+src = "contracts"
+out = "generated"
+`,
+  );
+  fs.writeFileSync(
+    path.join(dir, "contracts", "Nested", "D.fsol"),
+    "pragma solidity ^0.8.25; contract D { uint public x; }\n",
+  );
+}
+
+function runTask(dir, binary, taskName) {
+  return spawnSync(process.execPath, [hardhatCli(), taskName], {
+    cwd: dir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      FHEC_BINARY_PATH: binary,
+      HARDHAT_DISABLE_TELEMETRY: "true",
+    },
+    timeout: 180_000,
+  });
+}
+
 test(
   "hardhat compile transpiles a no-FHE .fsol and writes artifacts",
   { skip: skipReason, timeout: 180_000 },
@@ -114,6 +163,36 @@ test(
       );
       assert.ok(fs.existsSync(path.join(dir, "generated", "C.sol")), "expected generated/C.sol");
       assert.ok(artifactExists(dir, "C.sol", "C"), "expected Hardhat artifact for C");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "hre.artifacts.readArtifact resolves a .fsol FQN end-to-end",
+  { skip: skipReason, timeout: 180_000 },
+  () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-hh-fqn-"));
+    try {
+      writeReadArtifactTaskProject(dir);
+      const compileResult = runCompile(dir, nativeBinary);
+      assert.equal(
+        compileResult.status,
+        0,
+        `compile failed\nstdout:\n${compileResult.stdout}\nstderr:\n${compileResult.stderr}`,
+      );
+      const taskResult = runTask(dir, nativeBinary, "fhec-test-read-artifact");
+      assert.equal(
+        taskResult.status,
+        0,
+        `task failed\nstdout:\n${taskResult.stdout}\nstderr:\n${taskResult.stderr}`,
+      );
+      const match = taskResult.stdout.match(/FHEC_TEST_RESULT:(.+)/);
+      assert.ok(match, `expected FHEC_TEST_RESULT marker in stdout:\n${taskResult.stdout}`);
+      const parsed = JSON.parse(match[1]);
+      assert.equal(parsed.contractName, "D");
+      assert.equal(parsed.sourceName, "generated/Nested/D.sol");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/hardhat-plugin/test/config.test.js
+++ b/packages/hardhat-plugin/test/config.test.js
@@ -11,7 +11,7 @@ const { spawnSync } = require("node:child_process");
 const { parseFhecToml, findConfig } = require("../dist/toml");
 const { versionSatisfies, parseSemver } = require("../dist/version");
 const {
-  mapSrcKeyToOut,
+  mapOverrideKey,
   rewriteSolidityOverrides,
   formatOverrideWarning,
 } = require("../dist/overrides");
@@ -73,40 +73,40 @@ test("findConfig walks upward and returns the nearest fhec.toml", () => {
   }
 });
 
-test("mapSrcKeyToOut rewrites a source-tree override key to out/", () => {
+test("mapOverrideKey rewrites a source-tree override key to out/", () => {
   assert.equal(
-    mapSrcKeyToOut("contracts/Foo.sol", "contracts", "generated"),
+    mapOverrideKey("contracts/Foo.sol", "contracts", "generated", undefined),
     "generated/Foo.sol",
   );
   assert.equal(
-    mapSrcKeyToOut("contracts/Path/File.sol", "contracts", "generated"),
+    mapOverrideKey("contracts/Path/File.sol", "contracts", "generated", undefined),
     "generated/Path/File.sol",
   );
   assert.equal(
-    mapSrcKeyToOut("contracts/Lib.sol:Lib", "contracts", "generated"),
+    mapOverrideKey("contracts/Lib.sol:Lib", "contracts", "generated", undefined),
     "generated/Lib.sol:Lib",
   );
   assert.equal(
-    mapSrcKeyToOut("./contracts/Foo.sol", "contracts", "generated"),
+    mapOverrideKey("./contracts/Foo.sol", "contracts", "generated", undefined),
     "generated/Foo.sol",
   );
 });
 
-test("mapSrcKeyToOut leaves keys that are not under srcDir", () => {
+test("mapOverrideKey leaves keys that are not under srcDir", () => {
   assert.equal(
-    mapSrcKeyToOut("generated/Foo.sol", "contracts", "generated"),
+    mapOverrideKey("generated/Foo.sol", "contracts", "generated", undefined),
     undefined,
   );
   assert.equal(
-    mapSrcKeyToOut("other/Foo.sol", "contracts", "generated"),
+    mapOverrideKey("other/Foo.sol", "contracts", "generated", undefined),
     undefined,
   );
   assert.equal(
-    mapSrcKeyToOut("contracts-extra/Foo.sol", "contracts", "generated"),
+    mapOverrideKey("contracts-extra/Foo.sol", "contracts", "generated", undefined),
     undefined,
   );
   assert.equal(
-    mapSrcKeyToOut("contracts/Foo.sol", "contracts", "contracts"),
+    mapOverrideKey("contracts/Foo.sol", "contracts", "contracts", undefined),
     undefined,
   );
 });

--- a/packages/hardhat-plugin/test/fqn.test.js
+++ b/packages/hardhat-plugin/test/fqn.test.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { translateFsolFqn } = require("../dist/fqn");
+
+function sampleManifest() {
+  return {
+    tool: "fhec",
+    version: "0.0.0",
+    files: [
+      {
+        output: "ERC20Confidential/ERC20ConfidentialLib.sol",
+        source: "ERC20Confidential/ERC20ConfidentialLib.fsol",
+        no_op: false,
+        mappings: [],
+      },
+      {
+        output: "B.sol",
+        source: "B.sol",
+        no_op: true,
+        mappings: [],
+      },
+    ],
+  };
+}
+
+test("translates a .fsol FQN under srcDir to the manifest output under outDir", () => {
+  const result = translateFsolFqn(
+    "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+    "contracts",
+    "generated",
+    sampleManifest(),
+  );
+  assert.equal(result, "generated/ERC20Confidential/ERC20ConfidentialLib.sol:ERC20ConfidentialLib");
+});
+
+test("translates a bare .fsol source path with no :Contract suffix", () => {
+  const result = translateFsolFqn(
+    "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol",
+    "contracts",
+    "generated",
+    sampleManifest(),
+  );
+  assert.equal(result, "generated/ERC20Confidential/ERC20ConfidentialLib.sol");
+});
+
+test("an unknown FQN passes through unchanged (returns undefined)", () => {
+  assert.equal(
+    translateFsolFqn("contracts/DoesNotExist.fsol:Name", "contracts", "generated", sampleManifest()),
+    undefined,
+  );
+});
+
+test("a plain .sol file under srcDir needs no alias", () => {
+  assert.equal(
+    translateFsolFqn("contracts/B.sol:B", "contracts", "generated", sampleManifest()),
+    undefined,
+  );
+});
+
+test("an FQN outside srcDir passes through unchanged", () => {
+  assert.equal(
+    translateFsolFqn("node_modules/lib/X.sol:X", "contracts", "generated", sampleManifest()),
+    undefined,
+  );
+});
+
+test("a bare contract name (no path) passes through unchanged", () => {
+  assert.equal(
+    translateFsolFqn("ERC20ConfidentialLib", "contracts", "generated", sampleManifest()),
+    undefined,
+  );
+});

--- a/packages/hardhat-plugin/test/overrides.test.js
+++ b/packages/hardhat-plugin/test/overrides.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { mapOverrideKey, rewriteSolidityOverrides, formatOverrideWarning } = require("../dist/overrides");
+
+function sampleManifest() {
+  return {
+    tool: "fhec",
+    version: "0.0.0",
+    files: [
+      {
+        output: "ERC20Confidential/ERC20ConfidentialLib.sol",
+        source: "ERC20Confidential/ERC20ConfidentialLib.fsol",
+        no_op: false,
+        mappings: [],
+      },
+    ],
+  };
+}
+
+test("mapOverrideKey rewrites a plain .sol key without needing a manifest", () => {
+  assert.equal(mapOverrideKey("contracts/B.sol", "contracts", "generated", undefined), "generated/B.sol");
+});
+
+test("mapOverrideKey rewrites a .fsol key via the manifest", () => {
+  assert.equal(
+    mapOverrideKey(
+      "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol",
+      "contracts",
+      "generated",
+      sampleManifest(),
+    ),
+    "generated/ERC20Confidential/ERC20ConfidentialLib.sol",
+  );
+});
+
+test("mapOverrideKey preserves a :Contract suffix on a .fsol key", () => {
+  assert.equal(
+    mapOverrideKey(
+      "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+      "contracts",
+      "generated",
+      sampleManifest(),
+    ),
+    "generated/ERC20Confidential/ERC20ConfidentialLib.sol:ERC20ConfidentialLib",
+  );
+});
+
+test("mapOverrideKey leaves a .fsol key alone when there is no manifest", () => {
+  assert.equal(
+    mapOverrideKey(
+      "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol",
+      "contracts",
+      "generated",
+      undefined,
+    ),
+    undefined,
+  );
+});
+
+test("mapOverrideKey leaves a .fsol key alone when the manifest has no matching entry", () => {
+  assert.equal(
+    mapOverrideKey("contracts/Missing.fsol", "contracts", "generated", sampleManifest()),
+    undefined,
+  );
+});
+
+test("mapOverrideKey leaves a key already under outDir alone", () => {
+  assert.equal(mapOverrideKey("generated/B.sol", "contracts", "generated", undefined), undefined);
+});
+
+test("mapOverrideKey leaves a key outside srcDir alone", () => {
+  assert.equal(mapOverrideKey("lib/B.sol", "contracts", "generated", undefined), undefined);
+});
+
+test("rewriteSolidityOverrides moves matching keys in place and reports notices", () => {
+  const overrides = {
+    "contracts/B.sol": { version: "0.8.26" },
+    "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol": { version: "0.8.26" },
+    "lib/Other.sol": { version: "0.8.20" },
+  };
+  const notices = rewriteSolidityOverrides(overrides, "contracts", "generated", sampleManifest());
+  assert.deepEqual(Object.keys(overrides).sort(), [
+    "generated/B.sol",
+    "generated/ERC20Confidential/ERC20ConfidentialLib.sol",
+    "lib/Other.sol",
+  ]);
+  assert.equal(overrides["generated/B.sol"].version, "0.8.26");
+  assert.equal(notices.length, 2);
+  assert.ok(notices.every((n) => n.action === "rewritten"));
+});
+
+test("rewriteSolidityOverrides skips a rewrite that would clobber an existing destination", () => {
+  const overrides = {
+    "contracts/B.sol": { version: "0.8.26" },
+    "generated/B.sol": { version: "0.8.20" },
+  };
+  const notices = rewriteSolidityOverrides(overrides, "contracts", "generated", undefined);
+  assert.deepEqual(notices, [{ from: "contracts/B.sol", to: "generated/B.sol", action: "skipped" }]);
+  assert.equal(overrides["contracts/B.sol"].version, "0.8.26");
+  assert.equal(overrides["generated/B.sol"].version, "0.8.20");
+});
+
+test("formatOverrideWarning mentions both rewritten and skipped keys", () => {
+  const message = formatOverrideWarning(
+    [
+      { from: "contracts/B.sol", to: "generated/B.sol", action: "rewritten" },
+      { from: "contracts/C.sol", to: "generated/C.sol", action: "skipped" },
+    ],
+    "contracts",
+    "generated",
+  );
+  assert.match(message, /Rewrote solidity\.overrides keys/);
+  assert.match(message, /"contracts\/B\.sol" -> "generated\/B\.sol"/);
+  assert.match(message, /Did not rewrite/);
+  assert.match(message, /"contracts\/C\.sol"/);
+});

--- a/packages/hardhat-plugin/test/verify.test.js
+++ b/packages/hardhat-plugin/test/verify.test.js
@@ -1,0 +1,171 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { installVerifyOverride } = require("../dist/verify");
+
+function writeManifest(sourcesDir, manifest) {
+  const dir = path.join(sourcesDir, ".fhec");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify(manifest));
+}
+
+function sampleManifest() {
+  return {
+    tool: "fhec",
+    version: "0.0.0",
+    files: [
+      {
+        output: "ERC20Confidential/ERC20ConfidentialLib.sol",
+        source: "ERC20Confidential/ERC20ConfidentialLib.fsol",
+        no_op: false,
+        mappings: [],
+      },
+    ],
+  };
+}
+
+function makeHre({ sourcesDir, hasVerifyTask, enabled = true }) {
+  const calls = [];
+  const originalRun = async (taskIdentifier, taskArguments, subtaskArguments) => {
+    calls.push({ taskIdentifier, taskArguments, subtaskArguments });
+    return "result";
+  };
+  const hre = {
+    config: {
+      fhec: { enabled, srcDir: "contracts", outDir: "generated" },
+      paths: { sources: sourcesDir },
+    },
+    tasks: hasVerifyTask ? { "verify:verify": {} } : {},
+    run: originalRun,
+  };
+  return { hre, calls, originalRun };
+}
+
+test("registers nothing when verify:verify is not a known task", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-verify-"));
+  try {
+    const { hre, originalRun } = makeHre({ sourcesDir: dir, hasVerifyTask: false });
+    installVerifyOverride(hre);
+    assert.equal(hre.run, originalRun);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("translates args.contract for a verify:verify run() call", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-verify-"));
+  try {
+    writeManifest(dir, sampleManifest());
+    const { hre, calls } = makeHre({ sourcesDir: dir, hasVerifyTask: true });
+    installVerifyOverride(hre);
+    assert.notEqual(hre.run, undefined);
+    await hre.run("verify:verify", {
+      address: "0xabc",
+      contract: "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0].taskArguments.contract,
+      "generated/ERC20Confidential/ERC20ConfidentialLib.sol:ERC20ConfidentialLib",
+    );
+    assert.equal(calls[0].taskArguments.address, "0xabc");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("also translates when the task identifier is an object form", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-verify-"));
+  try {
+    writeManifest(dir, sampleManifest());
+    const { hre, calls } = makeHre({ sourcesDir: dir, hasVerifyTask: true });
+    installVerifyOverride(hre);
+    await hre.run(
+      { task: "verify:verify" },
+      { contract: "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib" },
+    );
+    assert.equal(
+      calls[0].taskArguments.contract,
+      "generated/ERC20Confidential/ERC20ConfidentialLib.sol:ERC20ConfidentialLib",
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("leaves args.contract untouched when it is not a string", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-verify-"));
+  try {
+    writeManifest(dir, sampleManifest());
+    const { hre, calls } = makeHre({ sourcesDir: dir, hasVerifyTask: true });
+    installVerifyOverride(hre);
+    await hre.run("verify:verify", { contract: 42 });
+    assert.equal(calls[0].taskArguments.contract, 42);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("leaves args.contract untouched when it is absent", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-verify-"));
+  try {
+    writeManifest(dir, sampleManifest());
+    const { hre, calls } = makeHre({ sourcesDir: dir, hasVerifyTask: true });
+    installVerifyOverride(hre);
+    await hre.run("verify:verify", { address: "0xabc" });
+    assert.deepEqual(calls[0].taskArguments, { address: "0xabc" });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("does not touch args for an unrelated task", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-verify-"));
+  try {
+    writeManifest(dir, sampleManifest());
+    const { hre, calls } = makeHre({ sourcesDir: dir, hasVerifyTask: true });
+    installVerifyOverride(hre);
+    await hre.run("compile", {
+      contract: "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+    });
+    assert.equal(
+      calls[0].taskArguments.contract,
+      "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("does not wrap run when the plugin is disabled", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-verify-"));
+  try {
+    const { hre, originalRun } = makeHre({ sourcesDir: dir, hasVerifyTask: true, enabled: false });
+    installVerifyOverride(hre);
+    assert.equal(hre.run, originalRun);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("with no manifest present, args.contract passes through unchanged", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fhec-verify-"));
+  try {
+    const { hre, calls } = makeHre({ sourcesDir: dir, hasVerifyTask: true });
+    installVerifyOverride(hre);
+    await hre.run("verify:verify", {
+      contract: "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+    });
+    assert.equal(
+      calls[0].taskArguments.contract,
+      "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Stacked on #67. Plugin only; nothing under `crates/` changes.

The plugin repoints `paths.sources` at `out`, so Hardhat names every contract `generated/Path/File.sol:Name`. Rather than a compatibility shim for the old `contracts/*.sol:Name` strings, you can now name the file you actually edit:

```ts
await ethers.getContractFactory(
  "contracts/ERC20Confidential/ERC20ConfidentialLib.fsol:ERC20ConfidentialLib",
);
```

The mapping is not guessed: `generated/.fhec/manifest.json` already records every `source` → `output` pair, and the plugin already loads it for solc span remapping. Only the path part is translated; the contract name never changes. An unknown name passes straight through, so Hardhat's own "contract not found" error is preserved, and with no manifest the wrapper does nothing.

**Covered:** `readArtifact`, `readArtifactSync`, `artifactExists`, `getBuildInfo`, `getBuildInfoSync`, `formArtifactPathFromFullyQualifiedName`; `solidity.overrides` keys; and `verify:verify`, for both `npx hardhat verify` and `run("verify:verify", ...)`.

**On verify.** The obvious implementation — overriding the task — depends on a third-party plugin's registration order and on it being installed at all. Wrapping `hre.run` inside `extendEnvironment` avoids both: Hardhat guarantees that runs after task registration finishes. Translating to the generated path is the correct direction here, because Etherscan must receive the source that produced the bytecode.

**One real bug found while building this.** Wrapping `hre.artifacts` as a plain object satisfying the public `Artifacts` type silently broke `hardhat compile`: Hardhat's own compile task calls `addValidArtifacts`, which the concrete class has but the public type does not declare. A `Proxy` forwards everything not explicitly translated. There is now an end-to-end test that compiles a project and reads an artifact by `.fsol` name from inside a live Hardhat task, which is what caught it.

This supersedes the `mapSrcKeyToOut` helper from #66 with `mapOverrideKey`, which handles the directory swap and the `.fsol` rename in one place; the earlier helper had no `.fsol` handling.

54 plugin tests pass. #54 stays open: fully-qualified names are now usable, but `getAllFullyQualifiedNames()` still enumerates `generated/` names, so stable FQNs remain a separate design question.