### PR TITLE
docs: correct the local-checkout install workaround for the unpublished packages

### DIFF
--- a/packages/fhec/README.md
+++ b/packages/fhec/README.md
@@ -21,9 +21,12 @@ first one it finds:
 2. **The platform package** for the current `process.platform`/`process.arch`,
    e.g. `@fhec/cli-darwin-arm64`. Resolved via `require.resolve`, with the
    binary expected at `<package>/bin/fhec`.
-3. **Dev fallback** — `../../target/release/fhec`, then
-   `../../target/debug/fhec`, resolved relative to `bin/fhec.js` (i.e. a
-   `cargo build` done directly in this monorepo checkout).
+3. **Dev fallback** — `../../../target/release/fhec`, then
+   `../../../target/debug/fhec`, resolved relative to `lib/resolve.js`
+   (this file lives at `packages/fhec/lib/resolve.js`, so the repo root is
+   three levels up). This layout exists only when the package sits in this
+   checkout (a workspace install or `link:`). A `file:` or registry copy
+   does not keep it; use `FHEC_BINARY_PATH` or a platform package.
 
 If none of these resolve, `fhec.js` exits 1 and prints every location it
 tried.

--- a/packages/hardhat-plugin/README.md
+++ b/packages/hardhat-plugin/README.md
@@ -12,6 +12,14 @@ this package does not bootstrap mocks.
 
 ## Install
 
+These packages are not on the npm registry yet. Do not run
+`pnpm add -D @fhec/hardhat-plugin` from a project outside this monorepo —
+that command fails until the first publish (see
+[`RELEASING.md`](../../RELEASING.md)). Use [Local checkout](#local-checkout)
+until then.
+
+After publish:
+
 ```sh
 npm install --save-dev @fhec/hardhat-plugin
 # or
@@ -142,12 +150,22 @@ registered.
 
 These packages are not on the npm registry yet. `pnpm add -D
 @fhec/hardhat-plugin` therefore cannot work from a project outside this
-monorepo: the plugin depends on `fhec` via `workspace:^0.1.0`, and the
-`fhec` wrapper looks for `target/{release,debug}/fhec` relative to the
-cargo checkout.
+monorepo: the plugin depends on `fhec` via `workspace:^0.1.0` (pnpm rewrites
+that to `^0.1.0` only on publish), and a `file:` copy of the wrapper cannot
+see this checkout's `target/{release,debug}/fhec`.
 
 Until the first publish (see [`RELEASING.md`](../../RELEASING.md)), wire a
 Hardhat 2 project to this checkout as follows.
+
+In this checkout, build the plugin and a native binary first. `dist/` is
+gitignored, and a `file:` install only packs `files: ["dist"]`:
+
+```sh
+pnpm --filter @fhec/hardhat-plugin run build
+cargo build --release -p fhec-cli
+```
+
+Then apply **both** of these workarounds. Neither is enough on its own.
 
 1. Add the plugin as a `file:` dependency:
 
@@ -155,8 +173,9 @@ Hardhat 2 project to this checkout as follows.
    pnpm add -D file:/abs/path/to/fhec/packages/hardhat-plugin
    ```
 
-2. pnpm materialises that `file:` dependency in its store, so `fhec@workspace:`
-   is not visible. Override it to the wrapper package:
+2. pnpm materialises that `file:` dependency in its store, so
+   `fhec@workspace:^0.1.0` is not visible. Override it to the wrapper
+   package:
 
    ```json
    {
@@ -173,9 +192,16 @@ Hardhat 2 project to this checkout as follows.
    checkout after the store copy. Point it at a binary you built:
 
    ```sh
-   cargo build --release -p fhec-cli
    export FHEC_BINARY_PATH=/abs/path/to/fhec/target/release/fhec
    ```
 
-Both the override and `FHEC_BINARY_PATH` are required. Neither is enough
-on its own.
+The override and `FHEC_BINARY_PATH` are both required for a `file:` install.
+
+Alternatively, if this checkout already has `pnpm install` and a native
+binary, `link:` the plugin instead. `link:` keeps `resolve.js` in this
+checkout, so the cargo fallback (or a staged platform package) works and
+you do not need the override or `FHEC_BINARY_PATH`:
+
+```sh
+pnpm add -D link:/abs/path/to/fhec/packages/hardhat-plugin
+```


### PR DESCRIPTION
Partial fix for #48. Docs-only — the actual fix (publish to npm) needs an explicit go-ahead from the repo owner; see the comment on the issue.

- Corrects the `fhec` wrapper's dev-fallback path description (`../../../target`, relative to `lib/resolve.js`, not `../../target`).
- Documents that `dist/` must be built before a `file:` install, since it's gitignored.
- Adds a `link:`-based workaround that avoids the override + `FHEC_BINARY_PATH` dance when the checkout already has a build.
- Clarifies the registry install line does not work yet.

## Test plan
- `pnpm -r run --if-present build` succeeds
- `pnpm --filter @fhec/hardhat-plugin test` passes