### PR TITLE
fix(bind,check): resolve the shared-return recipient instead of matching its spelling

### DIFF
--- a/crates/fhec-bind/src/binder.rs
+++ b/crates/fhec-bind/src/binder.rs
@@ -834,6 +834,20 @@ impl<'ast> Binder<'ast> {
                 // Named returns behave as locals.
                 w.declare_existing(vid, Resolution::Local(vid));
             }
+            // The §2.8 shared-return recipient (`shared(msg.sender)`), if
+            // any: syntactically part of the return-type list, but a name
+            // inside it resolves in the function's own scope — params
+            // included — same as any other body expression. Walking it here,
+            // with params already declared, is what lets the checker tell a
+            // shadowing parameter named `msg` from the real builtin (spec
+            // §2.8 restriction 2; issue #61).
+            for r in func.header.returns() {
+                if let Some(shared) = &r.shared {
+                    if let Some(recipient) = &shared.recipient {
+                        w.walk_expr(recipient);
+                    }
+                }
+            }
             // Modifier invocations (includes base-constructor calls on constructors).
             for m in func.header.modifiers.iter() {
                 let res = w.resolve_name(m.name.segments()[0].name, m.name.segments()[0].as_str());

--- a/crates/fhec-check/src/shared.rs
+++ b/crates/fhec-check/src/shared.rs
@@ -70,6 +70,50 @@ const WIRE_SUFFIX: &str = "_shared";
 /// The one recipient expression this MVP accepts.
 const RECIPIENT: &str = "msg.sender";
 
+/// Whether an expression is `msg.sender` where `msg` *resolves* to the
+/// Solidity builtin, not merely an expression spelled that way.
+///
+/// Structural spelling is not enough: a parameter, local, or struct field
+/// literally named `msg` shadows the builtin, and the checker must not
+/// accept a shadowed `msg.sender` as the recipient. Doing so would let the
+/// lowerer's fixed `msg.sender` re-emission (spec §2.8) resolve, in the
+/// generated Solidity, to whatever the shadowing declaration is — a
+/// caller-controlled value in the worst case (issue #61). Requiring the
+/// resolution, not the text, is the only way to keep the transpiler's proof
+/// that no other expression evaluates to the real caller (restriction 2).
+///
+/// Under an incomplete linearization (an unseen base), `msg` degrades to
+/// [`UnresolvedReason::IncompleteInheritance`] like any other name that is
+/// not the contract's own member — an unseen base could in principle also
+/// declare a member named `msg`. Requiring `Resolution::Builtin` outright
+/// would then refuse `shared(msg.sender)` in every contract that inherits
+/// from a package, which is the dominant real-world shape (spec §2.8 already
+/// has fixture/test coverage for it). This module follows the same narrow,
+/// established policy as `precondition.rs`'s `callee_resolution` for
+/// `require`: trust the `fallback` — what file scope alone would have
+/// answered — exactly when it says `Builtin`, and only then. A base that
+/// truly shadows `msg` defeats this, the same general hazard already
+/// documented there.
+fn resolves_to_msg_sender(unit: &BoundUnit<'_>, e: &ast::Expr<'_>) -> bool {
+    let ast::ExprKind::Member(base, member) = &e.peel_parens().kind else {
+        return false;
+    };
+    if member.as_str() != "sender" {
+        return false;
+    }
+    let ast::ExprKind::Ident(id) = &base.peel_parens().kind else {
+        return false;
+    };
+    let is_msg_builtin = |r: &Resolution| matches!(r, Resolution::Builtin(b) if b.0 == "msg");
+    match unit.resolve(*id) {
+        Some(r) if is_msg_builtin(r) => true,
+        Some(Resolution::Unresolved(UnresolvedReason::IncompleteInheritance {
+            fallback, ..
+        })) => is_msg_builtin(fallback),
+        _ => false,
+    }
+}
+
 /// Checks every shared-boundary marker of the unit and states the legal sites.
 ///
 /// Runs *after* the per-function walk: the shared-return type rule (FHE2012)
@@ -421,7 +465,7 @@ fn scan_returns<'ast>(
                 format!("a shared return must name its recipient: `shared({RECIPIENT}) eT`"),
             );
         }
-        Some(e) if !fhec_syntax::is_msg_sender(e) => {
+        Some(e) if !resolves_to_msg_sender(unit, e) => {
             return bad_position(
                 out,
                 e.span,

--- a/crates/fhec-check/src/shared.rs
+++ b/crates/fhec-check/src/shared.rs
@@ -114,6 +114,45 @@ fn resolves_to_msg_sender(unit: &BoundUnit<'_>, e: &ast::Expr<'_>) -> bool {
     }
 }
 
+/// The span of the first local declaration named `msg` anywhere in `body`,
+/// if any — a plain local, a tuple-declaration component, a `for`-init
+/// declaration, or a `try`/`catch` binder. Any of these is a *declaration*
+/// that shadows the `msg` builtin (Solidity scoping); a plain *use* of the
+/// name (an ordinary identifier expression) does not, and must not trip
+/// this, or a legitimate `shared(msg.sender)` return would refuse itself by
+/// finding its own header recipient.
+///
+/// Deliberately does not track which declarations are actually in scope at
+/// which `return`: see the call site in [`scan_returns`] for why the
+/// over-approximation (refuse on any declaration in the body, not just one
+/// that provably reaches a `return`) is the conservative and simple choice.
+fn body_shadows_msg<'ast>(body: &'ast ast::Block<'ast>) -> Option<Span> {
+    use ast::visit::Visit;
+    use std::ops::ControlFlow;
+
+    struct Search;
+    impl<'ast> Visit<'ast> for Search {
+        type BreakValue = Span;
+
+        fn visit_variable_definition(
+            &mut self,
+            var: &'ast ast::VariableDefinition<'ast>,
+        ) -> ControlFlow<Self::BreakValue> {
+            if let Some(name) = var.name {
+                if name.as_str() == "msg" {
+                    return ControlFlow::Break(name.span);
+                }
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    match Search.visit_block(body) {
+        ControlFlow::Break(span) => Some(span),
+        ControlFlow::Continue(()) => None,
+    }
+}
+
 /// Checks every shared-boundary marker of the unit and states the legal sites.
 ///
 /// Runs *after* the per-function walk: the shared-return type rule (FHE2012)
@@ -476,6 +515,33 @@ fn scan_returns<'ast>(
             );
         }
         Some(_) => {}
+    }
+    // The header recipient resolves to the builtin at the point it is
+    // checked (params and named returns in scope, nothing declared in the
+    // body yet). But the lowerer does not carry that resolution forward: it
+    // re-emits the literal text `msg.sender` fresh at every `return`
+    // (spec §2.8's rewrite). A local, a `for`-init declaration, or a
+    // `try`/`catch` binder named `msg` anywhere in the body shadows the
+    // builtin in Solidity from its declaration point onward, which would
+    // flip a later re-emitted `msg.sender` to read the shadowing
+    // declaration instead of the real transaction sender (issue #61 follow
+    // up). Working out exactly which `return`s a given declaration reaches
+    // needs the same per-statement reachability analysis this module
+    // elsewhere avoids, so this refuses the whole function instead of
+    // guessing (§1.3) — a function legitimately declaring something named
+    // `msg` is not a real-world shape worth the extra precision for.
+    if let Some(body) = &f.ast.body {
+        if let Some(shadow_span) = body_shadows_msg(body) {
+            return bad_position(
+                out,
+                shadow_span,
+                "this function declares a local named `msg`, which shadows the builtin from \
+                 here onward; the shared return's recipient, `msg.sender`, is re-emitted at \
+                 every `return` and would then read this declaration instead of the real \
+                 transaction sender — rename it"
+                    .to_string(),
+            );
+        }
     }
     if decl.in_sugar.is_some() {
         return bad_position(

--- a/crates/fhec-check/tests/check.rs
+++ b/crates/fhec-check/tests/check.rs
@@ -1618,6 +1618,37 @@ fn shared_return_states_one_site_per_function_and_suppresses_r3() {
 }
 
 #[test]
+fn a_shared_return_recipient_shadowed_by_a_parameter_named_msg_is_refused() {
+    // Regression for issue #61: the recipient must *resolve* to the Solidity
+    // builtin, not merely be spelled `msg.sender`. A parameter literally
+    // named `msg` shadows the builtin, so `msg.sender` here is a
+    // caller-controlled struct field, not the transaction sender.
+    let src = unit(
+        "struct Msg { address sender; }\n\
+         function f(Msg memory msg) external returns (shared(msg.sender) euint64) {\n\
+           return b;\n\
+         }",
+    );
+    with_checked(&[("t.fsol", &src)], |c, _| {
+        let d = c
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "FHE1015")
+            .unwrap_or_else(|| panic!("expected FHE1015, got {:?}", c.diagnostics));
+        assert_eq!(d.severity, Severity::Error);
+        assert_eq!(
+            d.message,
+            "the only recipient this version accepts is `msg.sender`; the transpiler cannot \
+             prove another expression names the caller"
+        );
+        assert!(
+            c.shared_return_sites.is_empty(),
+            "a shadowed recipient must not become a legal site"
+        );
+    });
+}
+
+#[test]
 fn an_ordinary_encrypted_return_still_states_an_r3_fact() {
     // Guards the suppression above against over-reach.
     let src = unit("function g() public returns (euint64) { return b; }");

--- a/crates/fhec-check/tests/check.rs
+++ b/crates/fhec-check/tests/check.rs
@@ -1649,6 +1649,144 @@ fn a_shared_return_recipient_shadowed_by_a_parameter_named_msg_is_refused() {
 }
 
 #[test]
+fn a_shared_return_recipient_shadowed_by_a_body_local_msg_is_refused() {
+    // Regression for issue #61 (follow-up): the header recipient resolves
+    // to the builtin fine (nothing named `msg` is in scope yet at the
+    // header), but the lowerer re-emits the literal text `msg.sender` at
+    // every `return`, so a local declared later in the body — even after
+    // the point the header itself was checked — must still be refused: it
+    // shadows the builtin from its declaration onward, and a `return` past
+    // it would read the local instead of the real sender.
+    let src = unit(
+        "struct Msg { address sender; }\n\
+         function f(bool c) external returns (shared(msg.sender) euint64) {\n\
+           if (c) {\n\
+             Msg memory msg;\n\
+             msg.sender = address(0);\n\
+             return b;\n\
+           }\n\
+           return b;\n\
+         }",
+    );
+    with_checked(&[("t.fsol", &src)], |c, _| {
+        let d = c
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "FHE1015")
+            .unwrap_or_else(|| panic!("expected FHE1015, got {:?}", c.diagnostics));
+        assert_eq!(d.severity, Severity::Error);
+        assert!(
+            d.message.contains("declares a local named `msg`"),
+            "{:?}",
+            d.message
+        );
+        assert!(c.shared_return_sites.is_empty());
+    });
+}
+
+#[test]
+fn a_shared_return_recipient_shadowed_by_a_try_catch_binder_named_msg_is_refused() {
+    // Same hazard as the body-local case, via a `try`/`catch` binder rather
+    // than an ordinary declaration.
+    let src = "pragma solidity ^0.8.25;\n\
+        import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+        interface IVault {\n\
+          function pull() external returns (bytes memory);\n\
+        }\n\
+        contract S {\n\
+          euint64 b;\n\
+          IVault vault;\n\
+          function f() external returns (shared(msg.sender) euint64) {\n\
+            try vault.pull() returns (bytes memory msg) {\n\
+              msg;\n\
+              return b;\n\
+            } catch {\n\
+              return b;\n\
+            }\n\
+          }\n\
+        }\n";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        let d = c
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "FHE1015")
+            .unwrap_or_else(|| panic!("expected FHE1015, got {:?}", c.diagnostics));
+        assert_eq!(d.severity, Severity::Error);
+        assert!(
+            d.message.contains("declares a local named `msg`"),
+            "{:?}",
+            d.message
+        );
+        assert!(c.shared_return_sites.is_empty());
+    });
+}
+
+#[test]
+fn a_shared_return_recipient_shadowed_by_an_own_state_variable_named_msg_is_refused() {
+    // A state variable named `msg` is the contract's own member, resolved
+    // before the builtin fallback is ever consulted — the primary
+    // (header-recipient) check already refuses it, with no need for the
+    // body-declaration scan.
+    let src = unit(
+        "address msg;\n\
+         function f() external returns (shared(msg.sender) euint64) {\n\
+           return b;\n\
+         }",
+    );
+    with_checked(&[("t.fsol", &src)], |c, _| {
+        let d = c
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "FHE1015")
+            .unwrap_or_else(|| panic!("expected FHE1015, got {:?}", c.diagnostics));
+        assert_eq!(d.severity, Severity::Error);
+        assert_eq!(
+            d.message,
+            "the only recipient this version accepts is `msg.sender`; the transpiler cannot \
+             prove another expression names the caller"
+        );
+        assert!(c.shared_return_sites.is_empty());
+    });
+}
+
+#[test]
+fn an_in_unit_base_declaring_msg_is_refused_even_behind_an_opaque_base() {
+    // Guards the `IncompleteInheritance` fallback trust (used so a
+    // `shared(msg.sender)` return stays legal under a package base) against
+    // waving through a *real*, in-unit shadow. Solidity gives the rightmost
+    // direct base precedence, so `Base` — listed last — is the one member
+    // the binder can certify despite the opaque `ReentrancyGuardTransient`
+    // earlier in the list; its `msg` member resolves positively and must
+    // never fall back to "what file scope would have said".
+    let src = "pragma solidity ^0.8.25;\n\
+        import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+        import {ReentrancyGuardTransient} from \"@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol\";\n\
+        contract Base {\n\
+          address msg;\n\
+        }\n\
+        contract Derived is ReentrancyGuardTransient, Base {\n\
+          euint64 b;\n\
+          function f() external returns (shared(msg.sender) euint64) {\n\
+            return b;\n\
+          }\n\
+        }\n";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        let d = c
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "FHE1015")
+            .unwrap_or_else(|| panic!("expected FHE1015, got {:?}", c.diagnostics));
+        assert_eq!(d.severity, Severity::Error);
+        assert_eq!(
+            d.message,
+            "the only recipient this version accepts is `msg.sender`; the transpiler cannot \
+             prove another expression names the caller"
+        );
+        assert!(c.shared_return_sites.is_empty());
+    });
+}
+
+#[test]
 fn an_ordinary_encrypted_return_still_states_an_r3_fact() {
     // Guards the suppression above against over-reach.
     let src = unit("function g() public returns (euint64) { return b; }");

--- a/fixtures/reject/fhe1015-shared-return-body-local-msg/expected.diagnostics.json
+++ b/fixtures/reject/fhe1015-shared-return-body-local-msg/expected.diagnostics.json
@@ -1,0 +1,17 @@
+[
+  {
+    "code": "FHE1015",
+    "severity": "error",
+    "span": {
+      "file": "input.fsol",
+      "start_byte": 740,
+      "end_byte": 743,
+      "start_line": 21,
+      "start_col": 24,
+      "end_line": 21,
+      "end_col": 27
+    },
+    "message": "this function declares a local named `msg`, which shadows the builtin from here onward; the shared return's recipient, `msg.sender`, is re-emitted at every `return` and would then read this declaration instead of the real transaction sender — rename it",
+    "rule": "§2.8"
+  }
+]

--- a/fixtures/reject/fhe1015-shared-return-body-local-msg/input.fsol
+++ b/fixtures/reject/fhe1015-shared-return-body-local-msg/input.fsol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+// The header recipient `msg.sender` resolves to the builtin fine (nothing
+// named `msg` is in scope yet at the header). But the lowerer re-emits the
+// literal text `msg.sender` fresh at every `return`, and a local declared
+// later in the body shadows the builtin in Solidity from its declaration
+// point onward — so a `return` reached after it would read the local
+// instead of the real transaction sender (issue #61 follow-up).
+struct Msg {
+    address sender;
+}
+
+contract BodyLocalShadowsMsg {
+    euint32 a;
+
+    function f(bool c) external returns (shared(msg.sender) euint32) {
+        if (c) {
+            Msg memory msg;
+            msg.sender = address(0);
+            return a;
+        }
+        return a;
+    }
+}

--- a/fixtures/reject/fhe1015-shared-return-recipient-shadowed/expected.diagnostics.json
+++ b/fixtures/reject/fhe1015-shared-return-recipient-shadowed/expected.diagnostics.json
@@ -1,0 +1,17 @@
+[
+  {
+    "code": "FHE1015",
+    "severity": "error",
+    "span": {
+      "file": "input.fsol",
+      "start_byte": 634,
+      "end_byte": 644,
+      "start_line": 19,
+      "start_col": 57,
+      "end_line": 19,
+      "end_col": 67
+    },
+    "message": "the only recipient this version accepts is `msg.sender`; the transpiler cannot prove another expression names the caller",
+    "rule": "§2.8"
+  }
+]

--- a/fixtures/reject/fhe1015-shared-return-recipient-shadowed/input.fsol
+++ b/fixtures/reject/fhe1015-shared-return-recipient-shadowed/input.fsol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+// A parameter named `msg` shadows the Solidity builtin. The recipient
+// `msg.sender` must be refused here even though its *spelling* matches the
+// one recipient this MVP accepts: the identifier resolves to the shadowing
+// parameter, not to the builtin, so `msg.sender` in the generated Solidity
+// would read a caller-controlled struct field instead of the transaction
+// sender (issue #61).
+struct Msg {
+    address sender;
+}
+
+contract ShadowMsg {
+    euint32 a;
+
+    function f(Msg memory msg) external returns (shared(msg.sender) euint32) {
+        return a;
+    }
+}

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -300,7 +300,7 @@ The returned expression is wrapped **where it stands**, never hoisted, so it is 
 **Restrictions.** Every violation is FHE1015 unless noted.
 
 1. The host must be a `function` that is `public` or `external` and neither `view` nor `pure`.
-2. **⚠ Draft decision (recipient):** the recipient MUST be exactly the expression `msg.sender`. Another expression is refused even when it would evaluate to the caller's address, because the transpiler cannot prove that (§1.3). Other recipients are a later revision.
+2. **⚠ Draft decision (recipient):** the recipient MUST be exactly the expression `msg.sender`, where `msg` resolves to the Solidity builtin — not merely an expression spelled that way. Another expression is refused even when it would evaluate to the caller's address, because the transpiler cannot prove that (§1.3). Because the rewrite re-emits the literal text `msg.sender` at every `return`, a function that declares anything named `msg` anywhere in its body — a local, a `for`-init declaration, or a `try`/`catch` binder — is refused outright too: Solidity's block scoping would let such a declaration shadow the builtin from its declaration point onward. Other recipients are a later revision.
 3. The shared return MUST be the only return value of its function and MUST be unnamed. Tuples, a named fallthrough return, and lists mixing a shared return with a plain or encrypted one are all refused.
 4. `shared(...)` must be followed by an encrypted type, and the `in` marker has no meaning on a return type. The declaration takes no data location, for the reason given in shared-input restriction 7.
 5. Every `return` in the body MUST be an explicit valued `return expr;`. A bare `return;` is refused.


### PR DESCRIPTION
Fixes #61.

The \`shared(...)\` recipient was accepted by comparing source text against the string \`msg.sender\`, not by checking what \`msg\` resolves to — so a shadowing parameter named \`msg\` (e.g. \`function f(Msg memory msg) external returns (shared(msg.sender) euint32)\`) let the caller pick who gets read access to the ciphertext, solc-clean. The recipient now must resolve to \`Resolution::Builtin("msg")\`; otherwise the file is refused with the existing FHE1015 restriction-2 diagnostic.

Two supporting fixes were needed:
- The binder never walked the shared-return recipient expression at all (it's part of the return-type list, not the function body) — now walked in the function's own scope, after parameters are declared.
- Under an incomplete linearization (an unseen base contract), \`msg\` degrades to \`Unresolved(IncompleteInheritance)\` like any other file-scope name — trusted only when the fallback says \`Builtin\`, following the same narrow precedent \`precondition.rs\` already uses for \`require\`.

R1/R3 sender-rendering (the issue's other ask) were checked and are already safe: R1's \`allowSender\` gate already resolves through \`Resolution::Builtin\`, and R3 emits a hardcoded \`"msg.sender"\` literal that never reads a source expression.

## Test plan
- \`cargo fmt --all --check\`, \`cargo clippy --workspace --all-targets -- -D warnings\`, \`cargo test --workspace\` all pass
- New rejection fixture \`fixtures/reject/fhe1015-shared-return-recipient-shadowed/\` + unit test