### PR TITLE
fix(check): stop scanning bodiless sugar and shared sites for FHE1022

### DIFF
--- a/crates/fhec-check/src/emit_trust.rs
+++ b/crates/fhec-check/src/emit_trust.rs
@@ -168,8 +168,23 @@ fn diagnostic_for(name: &str, res: &Resolution, span: Span) -> Diagnostic {
 
 /// Every function id that at least one collected site or ACL fact will need
 /// to write a generated `FHE.` call in. `precondition_sites` is the only
-/// site kind that never does (it only locates the materialization point for
-/// the others), so it is intentionally excluded.
+/// *whole* site kind that never does (it only locates the materialization
+/// point for the others), so it is intentionally excluded.
+///
+/// The three boundary-sugar kinds (`sugar_sites`, `shared_input_sites`,
+/// `shared_return_sites`) additionally rewrite a *bodiless* declaration's
+/// signature only — an interface method or abstract function with no body
+/// (spec §2.3 restriction 3, §2.8): `crates/fhec-lower/src/pass_ops.rs`
+/// returns before writing any generated call once `!has_body`
+/// (`expand_function_sugar`, `expand_shared_inputs`) or when
+/// `return_exprs` is empty (`expand_shared_returns`, which has no
+/// `has_body` field of its own — an empty `return_exprs` is how a bodiless
+/// `SharedReturnSite` is spelled). Counting those bodiless sites here would
+/// refuse FHE1022 on a shadow that can never actually retarget a generated
+/// call (#84). Every other site kind here is only ever collected while
+/// walking a function body (operators, ternaries, `if`, compound/incdec,
+/// cast sugar, ACL facts), so a bodiless declaration structurally cannot
+/// produce one and no filter is needed for them.
 fn functions_writing_fhe(out: &CheckedUnit) -> impl Iterator<Item = FunctionId> + '_ {
     out.operator_sites
         .iter()
@@ -179,9 +194,24 @@ fn functions_writing_fhe(out: &CheckedUnit) -> impl Iterator<Item = FunctionId> 
         .chain(out.compound_sites.iter().map(|s| s.function))
         .chain(out.incdec_sites.iter().map(|s| s.function))
         .chain(out.cast_sugar_sites.iter().map(|s| s.function))
-        .chain(out.sugar_sites.iter().map(|s| s.function))
-        .chain(out.shared_input_sites.iter().map(|s| s.function))
-        .chain(out.shared_return_sites.iter().map(|s| s.function))
+        .chain(
+            out.sugar_sites
+                .iter()
+                .filter(|s| s.has_body)
+                .map(|s| s.function),
+        )
+        .chain(
+            out.shared_input_sites
+                .iter()
+                .filter(|s| s.has_body)
+                .map(|s| s.function),
+        )
+        .chain(
+            out.shared_return_sites
+                .iter()
+                .filter(|s| !s.return_exprs.is_empty())
+                .map(|s| s.function),
+        )
         .chain(out.acl.storage_writes.iter().map(|s| s.function))
         .chain(out.acl.external_args.iter().map(|s| s.function))
         .chain(out.acl.returns.iter().map(|s| s.function))

--- a/crates/fhec-check/tests/check.rs
+++ b/crates/fhec-check/tests/check.rs
@@ -3908,6 +3908,123 @@ fn fhe1022_bodiless_multi_in_declaration_is_not_scanned() {
     assert!(codes_for_source(src).is_empty());
 }
 
+/// Issue #84: a bodiless declaration's single `in` parameter also never
+/// lowers through the general (non-batch) conversion call — `pass_ops.rs`
+/// returns before writing one whenever `!has_body` — so a shadow of `FHE`
+/// itself (not just the batch-materializer names) must not refuse it
+/// either.
+#[test]
+fn fhe1022_bodiless_single_in_declaration_is_not_scanned() {
+    let src = r#"
+        pragma solidity ^0.8.25;
+        import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+        contract FakeLib {}
+        abstract contract Victim {
+            FakeLib FHE;
+            function f(in euint32 amount) external virtual;
+        }
+    "#;
+    assert!(codes_for_source(src).is_empty());
+}
+
+/// Regression: the same shadow, but the declaration now has a body — the
+/// conversion prelude does write an `FHE.` call, so this must still refuse
+/// (no over-correction to the #60/#79 fix).
+#[test]
+fn fhe1022_with_body_single_in_declaration_shadow_is_refused() {
+    let src = r#"
+        pragma solidity ^0.8.25;
+        import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+        contract FakeLib {}
+        contract Victim {
+            FakeLib FHE;
+            function f(in euint32 amount) external {
+                amount;
+            }
+        }
+    "#;
+    assert_eq!(codes_for_source(src), ["FHE1022"]);
+}
+
+/// Issue #84: a bodiless `in shared` declaration rewrites its signature
+/// only (`expand_shared_inputs` returns before writing the `FHE.` receive
+/// call whenever `!has_body`), so a shadow of `FHE` must not refuse it.
+#[test]
+fn fhe1022_bodiless_shared_input_declaration_is_not_scanned() {
+    let src = r#"
+        pragma solidity ^0.8.25;
+        import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+        contract FakeLib {}
+        abstract contract Victim {
+            FakeLib FHE;
+            function g(in shared euint32 amount) external virtual;
+        }
+    "#;
+    assert!(codes_for_source(src).is_empty());
+}
+
+/// Regression: the same shadow, but with a body — `expand_shared_inputs`
+/// does write the `FHE.` receive call, so this must still refuse.
+#[test]
+fn fhe1022_with_body_shared_input_shadow_is_refused() {
+    let src = r#"
+        pragma solidity ^0.8.25;
+        import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+        contract FakeLib {}
+        contract Victim {
+            FakeLib FHE;
+            euint32 a;
+            function g(in shared euint32 amount) external {
+                a = amount;
+            }
+        }
+    "#;
+    assert_eq!(codes_for_source(src), ["FHE1022"]);
+}
+
+/// Issue #84: a bodiless `returns (shared(msg.sender) eT)` declaration has
+/// no `return` statements to wrap (`return_exprs` is empty), so
+/// `expand_shared_returns` never writes a `share(...)` call for it — a
+/// shadow of `FHE` must not refuse it.
+#[test]
+fn fhe1022_bodiless_shared_return_declaration_is_not_scanned() {
+    let src = r#"
+        pragma solidity ^0.8.25;
+        import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+        contract FakeLib {}
+        abstract contract Victim {
+            FakeLib FHE;
+            function h() external virtual returns (shared(msg.sender) euint64);
+        }
+    "#;
+    assert!(codes_for_source(src).is_empty());
+}
+
+/// Regression: the same shadow, but with a body and a `return` — this must
+/// still refuse.
+#[test]
+fn fhe1022_with_body_shared_return_shadow_is_refused() {
+    let src = r#"
+        pragma solidity ^0.8.25;
+        import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+        contract FakeLib {}
+        contract Victim {
+            FakeLib FHE;
+            euint64 b;
+            function h() external returns (shared(msg.sender) euint64) {
+                return b;
+            }
+        }
+    "#;
+    assert_eq!(codes_for_source(src), ["FHE1022"]);
+}
+
 /// Round-4 regression: an in-unit `import "./FHE.sol"` combined with an
 /// unrelated unseen/external base — issue #47's shape, and an ordinary,
 /// common pattern (e.g. a token contract that both vendors the profile


### PR DESCRIPTION
Fixes #84.

\`functions_writing_fhe\` (issue #60/#79's FHE1022 shadow check, merged in PR #78) counted bodiless \`sugar_sites\`, \`shared_input_sites\`, and \`shared_return_sites\` when deciding which functions need the trust check — but \`crates/fhec-lower/src/pass_ops.rs\` never actually writes an \`FHE.\` call for those site kinds on a bodiless declaration (an interface method or abstract function). This caused a spurious FHE1022 refusal when a shadowing symbol was in scope but nothing was ever going to be generated there.

Filtered the same way the existing batch-materializer scan already does (\`has_body\` / non-empty \`return_exprs\`). All other site kinds (operators, ternary, encrypted-if, compound/incdec, cast sugar, ACL facts) are only ever collected while walking a function body, so they structurally can't fire on a bodiless declaration — no filter needed there.

## Test plan
- \`cargo fmt --all --check\`, \`cargo clippy --workspace --all-targets -- -D warnings\`, \`cargo test --workspace\` all pass
- 3 new "bodiless + shadow → no FHE1022" tests, plus 3 matching "same shape with a body → still refused" regression tests