### PR TITLE
fix(bind): give param/return/struct-field types their owner's contract scope

### DIFF
--- a/crates/fhec-bind/src/binder.rs
+++ b/crates/fhec-bind/src/binder.rs
@@ -756,9 +756,17 @@ impl<'ast> Binder<'ast> {
         for vi in 0..self.unit.vars.len() {
             let (file, contract, decl) = {
                 let v = &self.unit.vars[vi];
+                // A param/return/struct-field type is written in the scope
+                // of its owning function or struct, not just the file: a
+                // library- or contract-nested type name (e.g. `D storage d`
+                // where `struct D` is declared inside the same library)
+                // only resolves via that owner's contract scope (issue
+                // #92). File-level owners (`FileConst`) have no such scope.
                 let contract = match v.owner {
                     VarOwner::State(c) => Some(c),
-                    _ => None,
+                    VarOwner::Param(f) | VarOwner::Return(f) => self.unit.function(f).contract,
+                    VarOwner::StructField(t) => self.unit.type_decl(t).contract,
+                    VarOwner::FileConst(_) | VarOwner::Local(_) => None,
                 };
                 (v.file, contract, v.decl)
             };

--- a/crates/fhec-bind/tests/bind.rs
+++ b/crates/fhec-bind/tests/bind.rs
@@ -148,6 +148,64 @@ fn unnamed_returns_are_collected_and_their_types_are_resolved() {
     });
 }
 
+/// Issue #92: a struct declared *inside* a library must resolve from that
+/// library's own signature-level positions — a function parameter/return
+/// type, and another struct's field type — exactly like a file-scope
+/// struct. Before the fix, `walk_bodies`'s signature-level pass only gave
+/// `VarOwner::State` variables their owning contract's scope; a
+/// library-nested type used as a `Param`/`Return`/`StructField` type
+/// resolved at file scope only, so it silently came back `Unresolved` and
+/// the checker treated the declared type as `Unknown`. That is the root
+/// cause of R1 stating no ACL fact at all for a storage-pointer write
+/// through a library-nested struct's field.
+#[test]
+fn library_nested_struct_type_resolves_at_signature_level() {
+    let src = r"
+        pragma solidity ^0.8.25;
+        library L {
+            struct Inner { uint256 x; }
+            struct Outer { Inner inner; }
+            function f(Outer storage o) public {}
+        }
+    ";
+    with_bound(&[("t.sol", src)], |bound, _| {
+        let (_, function) = bound
+            .functions()
+            .find(|(_, f)| f.name_str.as_deref() == Some("f"))
+            .expect("function is collected");
+        assert_eq!(function.params.len(), 1);
+        let param = bound.var(function.params[0]);
+        assert!(
+            matches!(param.owner, VarOwner::Param(_)),
+            "{:?}",
+            param.owner
+        );
+        let param_res = bound.resolve_span(param.decl.ty.span);
+        assert!(
+            matches!(param_res, Some(Resolution::TypeName(_))),
+            "{param_res:?}"
+        );
+
+        // `Outer`'s own field `inner: Inner` — another type nested in the
+        // same library — must resolve the same way.
+        let (_, outer) = bound
+            .type_decls()
+            .find(|(_, t)| t.name.as_str() == "Outer")
+            .expect("Outer is collected");
+        let TypeDeclKind::Struct(s) = &outer.kind else {
+            panic!("Outer is a struct");
+        };
+        let field = s.fields.iter().next().expect("Outer has a field");
+        let field_res = bound.resolve_span(field.ty.span);
+        assert!(
+            matches!(field_res, Some(Resolution::TypeName(_))),
+            "{field_res:?}"
+        );
+
+        assert!(bound.diagnostics().is_empty(), "{:?}", bound.diagnostics());
+    });
+}
+
 #[test]
 fn imports_aliased_glob_and_namespace() {
     let a = r"

--- a/crates/fhec-check/src/decl.rs
+++ b/crates/fhec-check/src/decl.rs
@@ -38,6 +38,28 @@ pub(crate) fn declared_ty<'ast>(unit: &BoundUnit<'ast>, trust: &Trust, ty: &ast:
 }
 
 /// Types a resolved single-segment custom type name.
+///
+/// `res` is unwrapped through `Unresolved(IncompleteInheritance)` first
+/// (same as `Trust::encrypted_type`/`external_input_type` above, via the
+/// same `Trust::unwrap_fallback` helper): an unseen/external base in a
+/// contract's linearization makes every name resolved through that
+/// contract's scope come back wrapped, even when the name is a struct/enum
+/// declared right there in the same unit. Matching on the wrapper directly
+/// would silently fall through to `Ty::Unknown` below, which is exactly the
+/// silent-under-grant hazard R1 must not have (issue #92): a struct/enum
+/// declared in a contract or library that also inherits an unseen base
+/// would then never type as its real declared type, at any position
+/// (parameter, return, another struct's field), so an encrypted write
+/// through one of its fields would state no ACL fact at all rather than
+/// the FHE4001-or-grant one it should.
+///
+/// The unwrap trusts what file scope would have said when an unseen base
+/// *could* redeclare `name` — the same tradeoff `Trust::unwrap_fallback`
+/// already accepts for `FHE`/encrypted-type names. A genuine mismatch (the
+/// unseen base actually declares a different, incompatible `D`) fails
+/// loudly at the solc gate (a struct-shape/field mismatch), not silently:
+/// the prime directive (spec §1.3) is about never miscompiling silently,
+/// and a solc-level type error is exactly the opposite of silent.
 pub(crate) fn custom_ty(unit: &BoundUnit<'_>, trust: &Trust, name: &str, res: &Resolution) -> Ty {
     if let Some(ety) = trust.encrypted_type(unit, name, res) {
         return Ty::Encrypted(ety);
@@ -45,7 +67,7 @@ pub(crate) fn custom_ty(unit: &BoundUnit<'_>, trust: &Trust, name: &str, res: &R
     if let Some(ety) = trust.external_input_type(unit, name, res) {
         return Ty::Plain(PlainTy::ExternalInput(ety));
     }
-    match res {
+    match Trust::unwrap_fallback(res) {
         Resolution::TypeName(id) => match &unit.type_decl(*id).kind {
             TypeDeclKind::Struct(_) => Ty::Plain(PlainTy::Struct(*id)),
             TypeDeclKind::Enum(_) => Ty::Plain(PlainTy::Enum(*id)),

--- a/crates/fhec-check/src/trust.rs
+++ b/crates/fhec-check/src/trust.rs
@@ -114,7 +114,7 @@ impl Trust {
     /// case — the binder cannot resolve the fallback itself precisely
     /// because an unseen base *could* shadow it, so every caller that wants
     /// to recognize a specific trusted shape underneath must unwrap first.
-    fn unwrap_fallback(res: &Resolution) -> &Resolution {
+    pub(crate) fn unwrap_fallback(res: &Resolution) -> &Resolution {
         match res {
             Resolution::Unresolved(UnresolvedReason::IncompleteInheritance {
                 fallback, ..

--- a/crates/fhec-check/tests/check.rs
+++ b/crates/fhec-check/tests/check.rs
@@ -3878,6 +3878,17 @@ fn fhe1022_batch_materializer_external_wire_type_is_shadowed() {
 
 /// Item 3: the plain encrypted type name side (`eT.wrap(...)`), not just the
 /// external wire-type side.
+///
+/// `ebool` here is both the state variable's name AND the literal type
+/// written on the `in` parameter itself (`in ebool flag`) — unlike the
+/// `externalEbool` wire-type case above, these two uses cannot be pulled
+/// apart: shadowing the name also shadows the parameter's own declared
+/// type. Since issue #92's fix gave parameter types their owning
+/// contract's scope during signature-level resolution (matching what
+/// function bodies already did), that shadow is now caught right there —
+/// `in` applied to a type that no longer resolves to the real `ebool` is
+/// FHE1010, refused before the function ever registers as a batch-
+/// materializer candidate for the later FHE1022 emit-time scan to reach.
 #[test]
 fn fhe1022_batch_materializer_plain_type_is_shadowed() {
     let src = r#"
@@ -3890,7 +3901,7 @@ fn fhe1022_batch_materializer_plain_type_is_shadowed() {
             function f(in ebool flag, in eaddress owner_) public {}
         }
     "#;
-    assert_eq!(codes_for_source(src), ["FHE1022"]);
+    assert_eq!(codes_for_source(src), ["FHE1010"]);
 }
 
 /// Item 5 (round-3 review): a bodiless multi-`in` declaration never reaches

--- a/crates/fhec-check/tests/check.rs
+++ b/crates/fhec-check/tests/check.rs
@@ -3067,6 +3067,65 @@ fn unseen_base_call_stays_unknown_and_explains_why() {
     });
 }
 
+/// Issue #92 review regression: an unseen/external base (`ReentrancyGuardTransient`,
+/// same stand-in `unseen_base_call_stays_unknown_and_explains_why` above uses)
+/// makes the enclosing contract's linearization incomplete, so every name
+/// resolved through its scope comes back wrapped in
+/// `Unresolved(IncompleteInheritance { fallback })` — including a struct
+/// declared in the very same file, used as a parameter type (`f`) or as
+/// another struct's field type (`g`'s `Wrap.inner`). `custom_ty` must unwrap
+/// that wrapper (the same way `Trust::encrypted_type` already does) rather
+/// than let the struct's type silently degrade to `Unknown`: an `Unknown`
+/// write target states no `EncryptedStorageWrite` fact at all, which is
+/// exactly the silent-no-grant hazard issue #92 was filed to close, just
+/// reached through incomplete inheritance instead of a library-nested
+/// struct declaration.
+#[test]
+fn a_struct_write_still_states_its_acl_fact_under_an_unseen_base() {
+    let src = r#"
+        pragma solidity ^0.8.25;
+        import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+        import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+
+        struct D {
+            euint64 bal;
+        }
+
+        contract C is ReentrancyGuardTransient {
+            struct Wrap {
+                D inner;
+            }
+
+            mapping(uint256 => Wrap) w;
+
+            function f(D storage d, euint64 v) internal {
+                d.bal = v;
+            }
+
+            function g(uint256 k, euint64 v) internal {
+                w[k].inner.bal = v;
+            }
+        }
+    "#;
+    with_checked(&[("t.fsol", src)], |c, snip| {
+        assert_eq!(
+            c.acl.storage_writes.len(),
+            2,
+            "both writes must state an R1 fact, not silently nothing: {:?}",
+            c.diagnostics
+        );
+        let spans: Vec<String> = c
+            .acl
+            .storage_writes
+            .iter()
+            .map(|w| snip(w.lvalue_span))
+            .collect();
+        assert!(spans.contains(&"d.bal".to_string()), "{spans:?}");
+        assert!(spans.contains(&"w[k].inner.bal".to_string()), "{spans:?}");
+        assert!(!c.has_errors(), "{:?}", c.diagnostics);
+    });
+}
+
 /// Wraps contract members in a unit that also declares a vault interface, for
 /// the §8.2 R2 interaction below.
 fn vault_unit(members: &str) -> String {

--- a/fixtures/acl/r1-incomplete-inheritance-nested-struct/expected.diagnostics.json
+++ b/fixtures/acl/r1-incomplete-inheritance-nested-struct/expected.diagnostics.json
@@ -1,0 +1,32 @@
+[
+  {
+    "code": "FHE4001",
+    "severity": "warning",
+    "span": {
+      "file": "input.fsol",
+      "start_byte": 1133,
+      "end_byte": 1138,
+      "start_line": 30,
+      "start_col": 9,
+      "end_line": 30,
+      "end_col": 14
+    },
+    "message": "encrypted write to `d.bal` targets a struct field, which carries no owner key, so its owner is not provably `msg.sender`; the sender grant is withheld here, so the transaction sender does not gain read access to a ciphertext that is not provably its own. Add an explicit grant if that is what you intend",
+    "rule": "§8.1"
+  },
+  {
+    "code": "FHE4001",
+    "severity": "warning",
+    "span": {
+      "file": "input.fsol",
+      "start_byte": 1207,
+      "end_byte": 1221,
+      "start_line": 34,
+      "start_col": 9,
+      "end_line": 34,
+      "end_col": 23
+    },
+    "message": "encrypted write to `w[k].inner.bal` targets a struct field, which carries no owner key, so its owner is not provably `msg.sender`; the sender grant is withheld here, so the transaction sender does not gain read access to a ciphertext that is not provably its own. Add an explicit grant if that is what you intend",
+    "rule": "§8.1"
+  }
+]

--- a/fixtures/acl/r1-incomplete-inheritance-nested-struct/expected.sol
+++ b/fixtures/acl/r1-incomplete-inheritance-nested-struct/expected.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+// A struct's type must still resolve correctly at signature level (a
+// parameter, or another struct's field) when the enclosing contract's own
+// linearization is INCOMPLETE because it inherits an unseen/external base
+// (`Ownable` here). An unseen base makes every name looked up through that
+// contract's scope come back wrapped in
+// `Unresolved(IncompleteInheritance { fallback })` instead of a plain file
+// scope lookup — the checker must unwrap that fallback (the same way
+// `Trust::encrypted_type`/`is_fhe_library` already do) rather than treat
+// the wrapper itself as an unrecognized type. Getting this wrong drops the
+// declared type to `Unknown`, which silently drops R1's ACL fact entirely
+// (issue #92 review fix): no `allowThis`, no FHE4001, nothing.
+struct D {
+    euint64 bal;
+}
+
+abstract contract C is Ownable {
+    struct Wrap {
+        D inner;
+    }
+
+    mapping(uint256 => Wrap) w;
+
+    function f(D storage d, euint64 v) internal {
+        d.bal = v;
+        FHE.allowThis(d.bal);
+    }
+
+    function g(uint256 k, euint64 v) internal {
+        w[k].inner.bal = v;
+        FHE.allowThis(w[k].inner.bal);
+    }
+}

--- a/fixtures/acl/r1-incomplete-inheritance-nested-struct/input.fsol
+++ b/fixtures/acl/r1-incomplete-inheritance-nested-struct/input.fsol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+// A struct's type must still resolve correctly at signature level (a
+// parameter, or another struct's field) when the enclosing contract's own
+// linearization is INCOMPLETE because it inherits an unseen/external base
+// (`Ownable` here). An unseen base makes every name looked up through that
+// contract's scope come back wrapped in
+// `Unresolved(IncompleteInheritance { fallback })` instead of a plain file
+// scope lookup — the checker must unwrap that fallback (the same way
+// `Trust::encrypted_type`/`is_fhe_library` already do) rather than treat
+// the wrapper itself as an unrecognized type. Getting this wrong drops the
+// declared type to `Unknown`, which silently drops R1's ACL fact entirely
+// (issue #92 review fix): no `allowThis`, no FHE4001, nothing.
+struct D {
+    euint64 bal;
+}
+
+abstract contract C is Ownable {
+    struct Wrap {
+        D inner;
+    }
+
+    mapping(uint256 => Wrap) w;
+
+    function f(D storage d, euint64 v) internal {
+        d.bal = v;
+    }
+
+    function g(uint256 k, euint64 v) internal {
+        w[k].inner.bal = v;
+    }
+}

--- a/fixtures/acl/r1-library-nested-struct/expected.diagnostics.json
+++ b/fixtures/acl/r1-library-nested-struct/expected.diagnostics.json
@@ -1,0 +1,17 @@
+[
+  {
+    "code": "FHE4001",
+    "severity": "warning",
+    "span": {
+      "file": "input.fsol",
+      "start_byte": 590,
+      "end_byte": 595,
+      "start_line": 17,
+      "start_col": 9,
+      "end_line": 17,
+      "end_col": 14
+    },
+    "message": "encrypted write to `d.bal` targets a struct field, which carries no owner key, so its owner is not provably `msg.sender`; the sender grant is withheld here, so the transaction sender does not gain read access to a ciphertext that is not provably its own. Add an explicit grant if that is what you intend",
+    "rule": "§8.1"
+  }
+]

--- a/fixtures/acl/r1-library-nested-struct/expected.sol
+++ b/fixtures/acl/r1-library-nested-struct/expected.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+// A struct declared INSIDE the same library as the function that writes
+// through it (the diamond-storage idiom real confidential-token libraries
+// use) must be recognized by R1 exactly like a file-scope struct (issue
+// #92): the struct field carries no owner key, so the write's owner is not
+// provably `msg.sender`, and the sender grant is withheld with FHE4001.
+library L {
+    struct D {
+        euint64 bal;
+    }
+
+    function f(D storage d, euint64 v) public {
+        d.bal = v;
+        FHE.allowThis(d.bal);
+    }
+}

--- a/fixtures/acl/r1-library-nested-struct/input.fsol
+++ b/fixtures/acl/r1-library-nested-struct/input.fsol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+// A struct declared INSIDE the same library as the function that writes
+// through it (the diamond-storage idiom real confidential-token libraries
+// use) must be recognized by R1 exactly like a file-scope struct (issue
+// #92): the struct field carries no owner key, so the write's owner is not
+// provably `msg.sender`, and the sender grant is withheld with FHE4001.
+library L {
+    struct D {
+        euint64 bal;
+    }
+
+    function f(D storage d, euint64 v) public {
+        d.bal = v;
+    }
+}


### PR DESCRIPTION
Fixes #92.

The signature-level type-resolution pass (\`Binder::walk_bodies\`) only gave contract-scope context to \`VarOwner::State\` variables — every other owner kind (\`Param\`, \`Return\`, \`StructField\`) always resolved its type annotation through file scope only. When a struct is declared inside a library and used as the type of that same library's own function parameter, or as the type of another struct's field, the lookup never found it, silently falling back to \`Ty::Unknown\`. Because the field's type then wasn't \`Ty::Encrypted\`, no \`EncryptedStorageWrite\` fact was ever created for a write through it — so R1 emitted nothing at all, not even the FHE4001 warning.

Fix: derive \`contract\` for \`Param\`/\`Return\` from the owning function, and for \`StructField\` from the owning struct — mirroring how a full function body walk (a separate, later pass) already resolves this correctly.

One incidental regression found and resolved: \`fhe1022_batch_materializer_plain_type_is_shadowed\` relied on the same underlying gap (a state var shadowing a plain type used directly on an \`in\` parameter) — with the fix, that shadow is now caught earlier as FHE1010 instead. Both diagnoses are refusals, so no miscompile risk either way; updated the test's assertion and comment.

## Test plan
- \`cargo fmt --all --check\`, \`cargo clippy --workspace --all-targets -- -D warnings\`, \`cargo test --workspace\` all pass
- \`pnpm --filter difftest test\` — 13/13 passing, including the full FHERC20 differential comparison against upstream fhenix-confidential-contracts
- New unit test \`library_nested_struct_type_resolves_at_signature_level\` (\`crates/fhec-bind/tests/bind.rs\`)
- New golden fixture \`fixtures/acl/r1-library-nested-struct\` (the issue's exact \`D\`/\`L.f\` shape), generated via \`fhec build --json --self-check\` and reviewed against spec §8.1