### PR TITLE
fix(check): close two definite-assignment gaps outside #82's named-return scope

### DIFF
--- a/crates/fhec-check/src/ops.rs
+++ b/crates/fhec-check/src/ops.rs
@@ -810,11 +810,13 @@ impl<'ast> FnChecker<'_, 'ast> {
                 // the target, rather than unconditionally becoming
                 // Assigned — otherwise the copy silently launders an
                 // uninitialized handle (spec §6; issue #82's hazard class,
-                // one function-local hop earlier).
+                // one function-local hop earlier). When the target has no
+                // tracked slot at all (storage, a struct field, or an
+                // array/mapping index — `lv.slot` is `None`), there is
+                // nothing to propagate INTO, so flag the copy directly
+                // instead of silently dropping it (issue #90, gap 1).
                 if rhs_unassigned {
-                    if let Some(idx) = lv.slot {
-                        self.slots[idx].state = AState::Unassigned;
-                    }
+                    self.propagate_or_flag_unassigned_copy(&lv, rhs.span);
                 }
             }
             Some(binop) => match &lty {
@@ -880,10 +882,22 @@ impl<'ast> FnChecker<'_, 'ast> {
                 // such marker at all (its own exit-point check is where
                 // that hazard is caught), so this is a strict superset of
                 // the previous behavior for that case, not a regression.
-                let taint = rhs.is_some_and(|r| self.rhs_is_unassigned(r));
+                //
+                // The span carried alongside the taint is the whole RHS
+                // (there is no more precise per-component span available
+                // here) — it is only ever consulted when a component has no
+                // tracked slot to propagate into (issue #90, gap 1), in
+                // which case it anchors the direct flag and `flag_uninit_in`
+                // dedups against `self.flagged`, so flagging it once per
+                // component that shares the same underlying pending marker
+                // still only reports that marker once.
+                let taint_span = match rhs {
+                    Some(r) if self.rhs_is_unassigned(r) => Some(r.span),
+                    _ => None,
+                };
                 for lel in lels.iter() {
                     if let Some(lel) = lel.as_ref().unspan() {
-                        self.write_tuple_component(lel, taint);
+                        self.write_tuple_component(lel, taint_span);
                     }
                 }
             }
@@ -893,21 +907,26 @@ impl<'ast> FnChecker<'_, 'ast> {
         // Captured BEFORE the write below, same reasoning as the simple
         // (non-tuple) assignment case: a self-copy component (`(r, x) =
         // (r, y);`) would otherwise see its own fresh write.
-        let rhs_unassigned = rhs.is_some_and(|r| self.rhs_is_unassigned(r));
-        self.write_tuple_component(lhs, rhs_unassigned);
+        let unassigned_span = match rhs {
+            Some(r) if self.rhs_is_unassigned(r) => Some(r.span),
+            _ => None,
+        };
+        self.write_tuple_component(lhs, unassigned_span);
     }
 
     /// Shared per-tuple-component write: records the definite-assignment
-    /// write, then applies `unassigned` (already decided by the caller —
-    /// either a precise per-component peek, or the union-taint fallback)
-    /// instead of the unconditional Assigned that `record_simple_write`
-    /// alone would leave. Recurses through a nested tuple lvalue so the
-    /// fallback path in `assign_tuple_lvalues` also reaches every leaf.
-    fn write_tuple_component(&mut self, lhs: &'ast ast::Expr<'ast>, unassigned: bool) {
+    /// write, then applies `unassigned_span` (already decided by the caller
+    /// — either a precise per-component peek, or the union-taint fallback;
+    /// `Some(span)` means the paired RHS was found unassigned, and `span` is
+    /// where that was detected) instead of the unconditional Assigned that
+    /// `record_simple_write` alone would leave. Recurses through a nested
+    /// tuple lvalue so the fallback path in `assign_tuple_lvalues` also
+    /// reaches every leaf.
+    fn write_tuple_component(&mut self, lhs: &'ast ast::Expr<'ast>, unassigned_span: Option<Span>) {
         if let ast::ExprKind::Tuple(lels) = &lhs.peel_parens().kind {
             for lel in lels.iter() {
                 if let Some(lel) = lel.as_ref().unspan() {
-                    self.write_tuple_component(lel, unassigned);
+                    self.write_tuple_component(lel, unassigned_span);
                 }
             }
             return;
@@ -917,10 +936,31 @@ impl<'ast> FnChecker<'_, 'ast> {
         // types. Solidity checks component compatibility; the checker only
         // needs the target type here to record the definite assignment.
         self.record_simple_write(lhs, &lty, &lv);
-        if matches!(lty, Ty::Encrypted(_)) && unassigned {
-            if let Some(idx) = lv.slot {
-                self.slots[idx].state = AState::Unassigned;
+        if matches!(lty, Ty::Encrypted(_)) {
+            if let Some(span) = unassigned_span {
+                self.propagate_or_flag_unassigned_copy(&lv, span);
             }
+        }
+    }
+
+    /// Propagates an unassigned-copy marker (already detected by the caller
+    /// via [`Self::rhs_is_unassigned`]) into the write target's tracked
+    /// slot, when it has one. A storage variable, a struct field, or an
+    /// array/mapping index has no tracked slot (`lv.slot` is `None`):
+    /// there is nothing local to mark, so the write's own unassigned-ness
+    /// would otherwise silently vanish instead of surfacing anywhere. Flag
+    /// it directly at `span` instead, using the same FHE2007 mechanism
+    /// (`flag_uninit_in`) every other "possibly uninitialized encrypted
+    /// value used here" site already uses, rather than inventing a new
+    /// diagnostic (issue #90, gap 1).
+    fn propagate_or_flag_unassigned_copy(&mut self, lv: &LvalueInfo, span: Span) {
+        if let Some(idx) = lv.slot {
+            self.slots[idx].state = AState::Unassigned;
+        } else {
+            self.flag_uninit_in(
+                span,
+                "as the value copied into storage, a struct field, or an array/mapping index",
+            );
         }
     }
 

--- a/crates/fhec-check/src/ops.rs
+++ b/crates/fhec-check/src/ops.rs
@@ -959,7 +959,8 @@ impl<'ast> FnChecker<'_, 'ast> {
         } else {
             self.flag_uninit_in(
                 span,
-                "as the value copied into storage, a struct field, or an array/mapping index",
+                "as part of the value copied into storage, a struct field, or an \
+                 array/mapping index",
             );
         }
     }

--- a/crates/fhec-check/src/walk.rs
+++ b/crates/fhec-check/src/walk.rs
@@ -782,17 +782,52 @@ impl<'a, 'ast> FnChecker<'a, 'ast> {
                 // it; a `break`/`return` inside the body skips it. A
                 // `continue` also runs `next` before `cond` is re-checked in
                 // real Solidity semantics — this typing (and its assignment
-                // effects) is not separately re-applied to each `continue`
-                // candidate captured below, only to the plain-fallthrough
-                // candidate: a narrow, safe-direction (over-strict, not a
-                // miss) precision gap, since a `continue` candidate can only
-                // end up *more* conservative than reality this way.
-                if !body_terminated {
+                // effects) is not separately re-applied to each individual
+                // `continue` candidate captured below, only ever computed
+                // once, here: a narrow, safe-direction (over-strict, not a
+                // miss) precision gap for THOSE candidates' own values,
+                // since a `continue` candidate can only end up *more*
+                // conservative than reality this way (spec §1.3).
+                //
+                // But `next` must still be visited at least once whenever a
+                // `continue` can reach it — i.e. whenever this loop's
+                // `continue` list (captured while walking `body` above) is
+                // non-empty — even when `body_terminated` (every body path
+                // takes `continue`/`break`/`return`, so the plain-
+                // fallthrough branch below never runs). Otherwise `next`'s
+                // own diagnostics (an uninitialized encrypted read inside
+                // it, or an encrypted loop-control expression) go
+                // completely unchecked on every path through this loop, a
+                // real miss rather than merely the over-strict gap above
+                // (issue #90, gap 2). Peeked from the still-open frame
+                // before it's popped below; typed exactly once, in a single
+                // `if`, so `next`'s own diagnostics never fire twice even
+                // when both conditions hold at once.
+                let next_reachable = !body_terminated
+                    || self
+                        .loop_continues
+                        .last()
+                        .is_some_and(|frame| !frame.is_empty());
+                if next_reachable {
                     if let Some(next) = next {
                         let ty = self.type_expr(next);
                         self.reject_encrypted_loop(&ty, next.span);
                     }
                 }
+                // `body_states` is snapshotted AFTER the `next_reachable`
+                // typing above, so when `!body_terminated` it correctly
+                // includes whatever `next` just assigned — unchanged from
+                // before. When `body_terminated` is true, `body_states` is
+                // still excluded from `candidates` below exactly as before:
+                // the newly-added `next_reachable` typing above runs purely
+                // for `next`'s own diagnostics and `pending`-marker side
+                // effects in that case, not to manufacture a fallthrough
+                // candidate that cannot really occur (every body path
+                // terminated, so control never reaches a plain "ran the
+                // body, now falls through to `next`" point at all — only
+                // each individual `continue`/`break` candidate below does,
+                // and those keep their own pre-`next` snapshot per the
+                // precision-gap note above).
                 let body_states = self.snapshot();
                 let breaks = self.loop_breaks.pop().unwrap_or_default();
                 let continues = self.loop_continues.pop().unwrap_or_default();

--- a/crates/fhec-check/src/walk.rs
+++ b/crates/fhec-check/src/walk.rs
@@ -784,10 +784,15 @@ impl<'a, 'ast> FnChecker<'a, 'ast> {
                 // real Solidity semantics — this typing (and its assignment
                 // effects) is not separately re-applied to each individual
                 // `continue` candidate captured below, only ever computed
-                // once, here: a narrow, safe-direction (over-strict, not a
-                // miss) precision gap for THOSE candidates' own values,
-                // since a `continue` candidate can only end up *more*
-                // conservative than reality this way (spec §1.3).
+                // once, here: a narrow, safe-direction precision gap for
+                // THOSE candidates' own values (spec §1.3). This is over-
+                // strict, not a miss, ONLY when `!body_terminated` (the
+                // plain-fallthrough state typed below already includes
+                // whatever `next` assigns, and every `continue` candidate
+                // stays a subset of that): once `body_terminated` forces the
+                // join-of-continues fallback below, the direction is no
+                // longer guaranteed one-sided — see that fallback's own
+                // comment for the case it exists to fix.
                 //
                 // But `next` must still be visited at least once whenever a
                 // `continue` can reach it — i.e. whenever this loop's
@@ -810,8 +815,41 @@ impl<'a, 'ast> FnChecker<'a, 'ast> {
                         .is_some_and(|frame| !frame.is_empty());
                 if next_reachable {
                     if let Some(next) = next {
+                        // When `body_terminated`, `self.slots` right now
+                        // holds whatever the LAST body path walked left
+                        // behind (e.g. one arm of an `if`/`else` where every
+                        // arm terminates) — not a state any path that
+                        // actually reaches `next` produces. The only paths
+                        // that reach `next` here are the `continue` points
+                        // captured while walking `body` above (a plain
+                        // fallthrough is impossible when `body_terminated`,
+                        // and `break` never runs `next`), so restore to
+                        // their join before typing `next`, then restore
+                        // back so `body_states`/`breaks`/`continues` below
+                        // are unaffected. Round-2 review of issue #90: typing
+                        // `next` against the wrong leftover state produced
+                        // both a false positive (a slot the reached-via-
+                        // `continue` path actually assigned, but the
+                        // untaken arm left unassigned) and a mirror miss
+                        // (the reverse — assigned in the untaken arm,
+                        // unassigned on the actual `continue` path).
+                        let restore_after = if body_terminated {
+                            let pre_next = self.snapshot();
+                            // Cloned (not borrowed) so `join_all`'s `&mut
+                            // self` below doesn't conflict with a borrow of
+                            // `self.loop_continues`.
+                            let frame = self.loop_continues.last().cloned().unwrap_or_default();
+                            let refs: Vec<&[AState]> = frame.iter().map(Vec::as_slice).collect();
+                            self.join_all(&refs);
+                            Some(pre_next)
+                        } else {
+                            None
+                        };
                         let ty = self.type_expr(next);
                         self.reject_encrypted_loop(&ty, next.span);
+                        if let Some(pre_next) = restore_after {
+                            self.restore(&pre_next);
+                        }
                     }
                 }
                 // `body_states` is snapshotted AFTER the `next_reachable`

--- a/crates/fhec-check/tests/check.rs
+++ b/crates/fhec-check/tests/check.rs
@@ -795,6 +795,68 @@ fn for_loop_mixed_continue_and_fallthrough_assignment_stays_clean() {
 }
 
 #[test]
+fn for_next_typed_against_continue_join_not_leftover_body_state_false_positive() {
+    // Round-2 review of issue #90: `next` is reachable only via the
+    // `continue` inside the `then` arm (the `else` arm always reverts), and
+    // that `continue` runs only after `c = a;` — so `c` IS definitely
+    // assigned on the one path that actually reaches `next`. Before this
+    // fix, `next` was typed against whatever `self.slots` held right after
+    // walking `body` — here, the leftover state from the LAST-walked arm
+    // (`else`, which never touched `c`) — producing a spurious FHE2007 on
+    // `c`'s read inside `next`.
+    let src = "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         library L {\n\
+           function f(bool p, euint64 a) internal {\n\
+             euint64 c;\n\
+             euint64 d;\n\
+             for (uint256 i = 0; i < 3; d = a + c) {\n\
+               if (p) { c = a; continue; } else { revert(\"x\"); }\n\
+             }\n\
+           }\n\
+         }";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        let fhe2007: Vec<_> = c
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "FHE2007")
+            .collect();
+        assert!(fhe2007.is_empty(), "{:?}", c.diagnostics);
+    });
+}
+
+#[test]
+fn for_next_typed_against_continue_join_catches_the_mirror_miss() {
+    // Mirror of the false positive above, arms swapped: `next` is
+    // reachable only via the `continue` BEFORE `c = a;` ever runs, so `c`
+    // is NOT assigned on the one path that actually reaches `next` — even
+    // though the (irrelevant, always-reverting) fallthrough path assigns
+    // it. Before this fix, `next` was typed against the fallthrough's
+    // leftover state (`c` assigned), silently missing the read.
+    let src = "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         library L {\n\
+           function f(bool p, euint64 a) internal {\n\
+             euint64 c;\n\
+             euint64 d;\n\
+             for (uint256 i = 0; i < 3; d = a + c) {\n\
+               if (p) { continue; }\n\
+               c = a;\n\
+               revert(\"x\");\n\
+             }\n\
+           }\n\
+         }";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        let fhe2007: Vec<_> = c
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "FHE2007")
+            .collect();
+        assert_eq!(fhe2007.len(), 1, "{:?}", c.diagnostics);
+    });
+}
+
+#[test]
 fn modifier_with_early_return_before_placeholder_still_flags_the_guarded_function() {
     // The function body itself assigns `res` on every path, but the
     // modifier can `return;` before `_;` runs, skipping the body entirely

--- a/crates/fhec-check/tests/check.rs
+++ b/crates/fhec-check/tests/check.rs
@@ -1046,6 +1046,71 @@ fn tuple_copy_from_a_call_rhs_is_unaffected_by_propagation() {
     });
 }
 
+// ---- issue #90 gap 1: an unassigned copy into a slot-less target ----------
+
+#[test]
+fn copy_of_an_unassigned_local_into_storage_is_flagged() {
+    // `x` may be unassigned when copied into the state variable `a`. A
+    // storage write has no tracked slot (`lv.slot` is `None`), so there is
+    // nothing local to propagate the unassigned marker into — before issue
+    // #90's fix this silently dropped the marker instead of flagging it.
+    assert_codes("euint32 x; if (p > 0) { x = a; } a = x;", &["FHE2007"]);
+}
+
+#[test]
+fn copy_of_an_unassigned_local_into_a_struct_field_is_flagged() {
+    // Issue #90's exact repro: a struct-field write is equally slot-less.
+    let src = "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         contract C {\n\
+           struct S { euint64 v; }\n\
+           S s;\n\
+           function f(bool cond, euint64 a) external {\n\
+             euint64 x;\n\
+             if (cond) { x = a; }\n\
+             s.v = x;\n\
+           }\n\
+         }";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        let fhe2007: Vec<_> = c
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "FHE2007")
+            .collect();
+        assert_eq!(fhe2007.len(), 1, "{:?}", c.diagnostics);
+    });
+}
+
+#[test]
+fn copy_of_an_unassigned_local_into_an_array_index_is_flagged() {
+    // A mapping/array-index write is also slot-less.
+    let src = "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         contract C {\n\
+           mapping(uint256 => euint64) arr;\n\
+           function f(bool cond, euint64 a, uint256 i) external {\n\
+             euint64 x;\n\
+             if (cond) { x = a; }\n\
+             arr[i] = x;\n\
+           }\n\
+         }";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        let fhe2007: Vec<_> = c
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "FHE2007")
+            .collect();
+        assert_eq!(fhe2007.len(), 1, "{:?}", c.diagnostics);
+    });
+}
+
+#[test]
+fn copy_of_a_definitely_assigned_local_into_storage_stays_clean() {
+    // Positive control: `x` is definitely assigned before the copy, so the
+    // storage write is unaffected by the slot-less-target fix.
+    assert_codes("euint32 x = a; a = x;", &[]);
+}
+
 #[test]
 fn inline_assembly_anywhere_in_the_body_fails_closed() {
     // This checker does not parse Yul, so it cannot rule out an assembly

--- a/crates/fhec-check/tests/check.rs
+++ b/crates/fhec-check/tests/check.rs
@@ -706,6 +706,94 @@ fn for_loop_zero_trip_does_not_count_the_increment_as_having_run() {
     });
 }
 
+// ---- issue #90 gap 2: `for`'s `next` on an all-`continue` body ------------
+
+#[test]
+fn for_next_is_typed_even_when_every_body_path_continues() {
+    // Every path through the body takes `continue`, so `body_terminated` is
+    // true and the plain-fallthrough branch that normally types `next`
+    // never runs. Before issue #90's fix, `next` was then never typed at
+    // all on this shape — not even for its own diagnostics — so `c`'s
+    // uninitialized read inside it went completely unchecked. `next`'s own
+    // ENCRYPTED_LOOP check (its assignment expression's type is the
+    // encrypted target's type) was equally skipped. Fixed: `next` is now
+    // typed once whenever this loop's `continue` list is non-empty, so both
+    // fire — `c`'s read (FHE2007) and `next`'s own ENCRYPTED_LOOP (FHE3021)
+    // — in addition to the pre-existing "named return `r` not assigned on
+    // every path" FHE2007 (still flagged either way, since a `for` loop's
+    // mandatory zero-trip candidate alone already forces that).
+    let src = "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         library L {\n\
+           function f(euint64 a) internal returns (euint64 r) {\n\
+             euint64 c;\n\
+             for (uint256 i = 0; i < 3; r = a + c) {\n\
+               continue;\n\
+             }\n\
+           }\n\
+         }";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        let mut codes: Vec<&str> = c.diagnostics.iter().map(|d| d.code).collect();
+        codes.sort();
+        assert_eq!(
+            codes,
+            vec!["FHE2007", "FHE2007", "FHE3021"],
+            "{:?}",
+            c.diagnostics
+        );
+    });
+}
+
+#[test]
+fn for_next_typing_does_not_double_fire_when_body_also_falls_through() {
+    // Positive/regression control for the fix above: when the body has BOTH
+    // a `continue` path and a genuine fallthrough path (an `if` with no
+    // `else`), `next` was already typed via the pre-existing
+    // `!body_terminated` branch — the new "any `continue` reaches `next`"
+    // condition is also true here, so this exercises the overlap. `next`'s
+    // own diagnostics (ENCRYPTED_LOOP here) must still fire exactly once,
+    // not twice, confirmed by exact diagnostic count.
+    let src = "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         library L {\n\
+           function f(bool cond, euint64 a) internal returns (euint64 r) {\n\
+             for (uint256 i = 0; i < 3; r = a) {\n\
+               if (cond) { continue; }\n\
+             }\n\
+           }\n\
+         }";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        let mut codes: Vec<&str> = c.diagnostics.iter().map(|d| d.code).collect();
+        codes.sort();
+        assert_eq!(codes, vec!["FHE2007", "FHE3021"], "{:?}", c.diagnostics);
+    });
+}
+
+#[test]
+fn for_loop_mixed_continue_and_fallthrough_assignment_stays_clean() {
+    // Positive control: `r` is assigned before the loop, the `continue`
+    // path never touches it (so it stays whatever it already was), and the
+    // fallthrough path re-assigns it from a definitely-assigned parameter.
+    // Every reachable exit — the mandatory zero-trip candidate, every
+    // `continue` candidate, and the fallthrough — sees `r` assigned, so
+    // typing `next` (a plain, non-encrypted counter increment here) on the
+    // overlap of both conditions must not introduce any new diagnostic.
+    let src = "pragma solidity ^0.8.25;\n\
+         import \"@fhenixprotocol/cofhe-contracts/FHE.sol\";\n\
+         library L {\n\
+           function f(bool cond, euint64 a, euint64 b) internal returns (euint64 r) {\n\
+             r = b;\n\
+             for (uint256 i = 0; i < 3; i = i + 1) {\n\
+               if (cond) { continue; }\n\
+               r = a;\n\
+             }\n\
+           }\n\
+         }";
+    with_checked(&[("t.fsol", src)], |c, _| {
+        assert!(c.diagnostics.is_empty(), "{:?}", c.diagnostics);
+    });
+}
+
 #[test]
 fn modifier_with_early_return_before_placeholder_still_flags_the_guarded_function() {
     // The function body itself assigns `res` on every path, but the


### PR DESCRIPTION
Fixes #90.

Two narrow gaps in the definite-assignment analysis built up across issue #82's 7-round fix (PR #83, merged):

1. **Copy into storage/a struct field/an array index silently dropped the marker.** \`rhs_is_unassigned\` correctly detects a copy from an unassigned encrypted value, but propagation only worked through a tracked local \`slot\` — a storage variable, struct field, or index has none, so the marker vanished with no diagnostic at all. Added \`propagate_or_flag_unassigned_copy\`: when there's no slot to propagate into, it now flags the copy directly via the existing \`flag_uninit_in\` (FHE2007) mechanism instead of silently dropping it.

2. **\`for\`'s \`next\` wasn't typed when every loop-body path takes \`continue\`/\`break\`/\`return\`.** This was a deliberate, mostly-safe-direction simplification — except when \`next\` is the only place a value gets assigned and every body path continues, in which case \`next\`'s own diagnostics (an uninitialized read, an encrypted-loop-control expression) were invisible. Now typed whenever at least one \`continue\` candidate reaches it.

## Test plan
- \`cargo fmt --all --check\`, \`cargo clippy --workspace --all-targets -- -D warnings\`, \`cargo test --workspace\` all pass — \`fhec-check\` went from 190 to 197 tests, zero regressions
- 7 new tests: gap 1 covers storage/struct-field/array-index repros plus a clean control; gap 2 covers the all-\`continue\` repro, an overlap case confirming no double-fire, and a clean control
- Verified both misses empirically with a scratch harness before writing the fix (confirmed each repro under-reported, then confirmed the fix corrects it)