### PR TITLE
fix(lower): align R2's FHE4002 rule tag with the catalog's §8.4

### DIFF
--- a/crates/fhec-lower/src/pass_acl.rs
+++ b/crates/fhec-lower/src/pass_acl.rs
@@ -312,7 +312,7 @@ fn rule_r2<'ast>(
                       encrypted argument; the callee must have been granted access elsewhere"
                 .to_string(),
             fixits: Vec::new(),
-            rule: Some("§8.2"),
+            rule: Some("§8.4"),
         });
         return Ok(());
     }

--- a/fixtures/acl/r2-view-warning/expected.diagnostics.json
+++ b/fixtures/acl/r2-view-warning/expected.diagnostics.json
@@ -12,6 +12,6 @@
       "end_col": 29
     },
     "message": "a `view` or `pure` function cannot grant ACL access to this call's encrypted argument; the callee must have been granted access elsewhere",
-    "rule": "§8.2"
+    "rule": "§8.4"
   }
 ]


### PR DESCRIPTION
Found during PR #98's review: R2's new view/pure guard emitted rule tag \`§8.2\` (R2's own section) for FHE4002, while the catalog entry and R3's own emission of the same code both use \`§8.4\`. Same diagnostic code should carry a consistent rule reference regardless of which pass emits it. Cosmetic, no behavior change.

## Test plan
- \`cargo fmt --all --check\`, \`cargo clippy --workspace --all-targets -- -D warnings\`, \`cargo test --workspace\` all pass